### PR TITLE
Add Mypy?

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 check-manifest = ">=0.25"
 pre-commit = "*"
 pytest-invenio = "*"
+pytest-mypy = "*"
 
 [packages]
 ic-data-repo = {editable=true, path="./site"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f91650ed17b79637d5aa7f9456178ae0e5df24a48f5a192733a78837c86d5ea7"
+            "sha256": "974fd832e3ba5168cdd9a9ce0ee1c83669c7cf8c60299a3ba61c3fbd5765e996"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -3744,6 +3744,48 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.1.5"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9",
+                "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d",
+                "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0",
+                "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3",
+                "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3",
+                "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade",
+                "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31",
+                "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7",
+                "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e",
+                "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7",
+                "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c",
+                "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b",
+                "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e",
+                "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531",
+                "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04",
+                "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a",
+                "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37",
+                "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a",
+                "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f",
+                "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84",
+                "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d",
+                "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f",
+                "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a",
+                "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf",
+                "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7",
+                "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02",
+                "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"
+            ],
+            "index": "pypi",
+            "markers": "python_version < '3.11' and python_version >= '3.9'",
+            "version": "==1.10.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
         "nodeenv": {
             "hashes": [
                 "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f",
@@ -3822,7 +3864,7 @@
                 "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
                 "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10' and python_version >= '3.6'",
             "version": "==7.1.3"
         },
         "pytest-cov": {
@@ -3865,6 +3907,15 @@
             ],
             "markers": "python_version >= '3.8' and python_version < '4'",
             "version": "==4.0.0"
+        },
+        "pytest-mypy": {
+            "hashes": [
+                "sha256:7638d0d3906848fc1810cb2f5cc7fceb4cc5c98524aafcac58f28620e3102053",
+                "sha256:f8458f642323f13a2ca3e2e61509f7767966b527b4d8adccd5032c3e7b4fd3db"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==0.10.3"
         },
         "pytest-pycodestyle": {
             "hashes": [
@@ -3966,6 +4017,14 @@
             ],
             "markers": "python_version < '3.11'",
             "version": "==2.0.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,20 @@ docstring-convention = "google"
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = true
+
+[tool.mypy]
+disallow_any_generics = true
+warn_unreachable = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = [
+       "flask_oauthlib.*",
+       "invenio_app.*",
+       "invenio_assets.*",
+       "invenio_oauthclient.*",
+       ]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+addopts = "--mypy --ignore=site/setup.py"

--- a/site/ic_data_repo/auth/oauth.py
+++ b/site/ic_data_repo/auth/oauth.py
@@ -1,11 +1,16 @@
 """Implement OAuth handlers."""
 
+from typing import Any
+
 import jwt
 import requests
 from flask import current_app
+from flask_oauthlib import OAuthRemote
 
 
-def info_handler(remote_app, response_data):
+def info_handler(
+    remote_app: OAuthRemote, response_data: dict[str, Any]
+) -> dict[str, Any]:
     """Extract account info from authorisation response.
 
     Extracts and validates the id_token returned as part of the OIDC workflow using


### PR DESCRIPTION
Provides the infrastructure for mypy usage via `pytest-mypy`. Uses a loose configuration that effectively makes typehinting optional. Adds hints to an oauth handler as an example.

I'm not 100% on this. Given the lack of typing in the Invenio and wider Flask ecosystems (Flask itself is typed) there are some questions about how much value we would derive.

Some pros:
- more informative function signatures - the oauth handler example is fairly pertinent as much of the code in the project will be handler functions plugged into the frameworks, the hints give at least some clue what data structures are being passed in although these are not being checked.
- Flask itself is typed so may be possible to derive more value on view functions (could consider tightening requirements for relevant modules).

Some cons:
- lots of modules will need to be added to the ignores in `pyproject.toml`.
- hints could end up being actively misleading if not checked.