### PR TITLE
Don't setup services in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
       - name: setup project virtual environment
         run: invenio-cli install
       - name: start services
-        run: invenio-cli services setup --no-demo-data
+        run: invenio-cli services start
       - name: run tests
         run: pipenv run pytest


### PR DESCRIPTION
Services only need to be started and not setup in order to run the tests so we can shave a bit of time off our CI workflows.