### PR TITLE
Use app_key

### DIFF
--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -167,8 +167,7 @@ if ICL_OAUTH_CLIENT_ID and ICL_OAUTH_CLIENT_SECRET and ICL_OAUTH_WELL_KNOWN_URL:
             access_token_url="https://login.microsoftonline.com/2b897507-ee8c-4575-830b-4f8267c3d307/oauth2/v2.0/token",  # noqa: E501
             access_token_method="POST",
             authorize_url="https://login.microsoftonline.com/2b897507-ee8c-4575-830b-4f8267c3d307/oauth2/v2.0/authorize",  # noqa: E501
-            consumer_key=ICL_OAUTH_CLIENT_ID,
-            consumer_secret=ICL_OAUTH_CLIENT_SECRET,
+            app_key="ICL_APP_CREDENTIALS",
         ),
         authorized_handler="invenio_oauthclient.handlers:authorized_signup_handler",
         disconnect_handler="invenio_oauthclient.handlers:disconnect_handler",
@@ -177,6 +176,10 @@ if ICL_OAUTH_CLIENT_ID and ICL_OAUTH_CLIENT_SECRET and ICL_OAUTH_WELL_KNOWN_URL:
         ),
         signup_options=dict(auto_confirm=True, send_register_msg=False),
     )
+    ICL_APP_CREDENTIALS = {
+        "consumer_key": ICL_OAUTH_CLIENT_ID,
+        "consumer_secret": ICL_OAUTH_CLIENT_SECRET,
+    }
 
 ACCOUNTS_LOGIN_VIEW_FUNCTION = (
     auto_redirect_login  # autoredirect to external login if enabled


### PR DESCRIPTION
Documentation around setting up SSO is limited. In addition to the [docs themselves](https://inveniordm.docs.cern.ch/customize/authentication/), it is largely found in [config.py](https://github.com/inveniosoftware/invenio-oauthclient/blob/v4.0.0/invenio_oauthclient/config.py) .

I assume the starting point for writing the current SSO integration config was taken [here from config.py](https://github.com/inveniosoftware/invenio-oauthclient/blob/4aaa9c55f00c9995b5c6836e278648e8bbd7574d/invenio_oauthclient/config.py#L63-L87). The current approach passes `consumer_key` and `consumer_secret` directly to Flask-OAuthLib whereas Invenio prefers to use lazy loading via config `app_key` .


The [invenio-oauthclient](https://github.com/inveniosoftware/invenio-oauthclient) module makes one reference to the `app_key` in configuration for remote apps in a wrapper around the [disconnect_handler](https://github.com/inveniosoftware/invenio-oauthclient/blob/4aaa9c55f00c9995b5c6836e278648e8bbd7574d/invenio_oauthclient/handlers/utils.py#L86). This only comes into play when a user tries to disconnect a remote app (an SSO service) from his account. As local logins won't be enabled, this situation can't arise as long as Imperial SSO is the only configured SSO service and as long as a user isn't created before an SSO login occurs.

I've put in a PR for the invenio-oauthclient [here](https://github.com/inveniosoftware/invenio-oauthclient/pull/337).


## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
