### PR TITLE
Add logged in user as default creator in submission form

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ exclude = "test_data/.*\\.py"
 
 [[tool.mypy.overrides]]
 module = [
+       "flask_login.*",
        "flask_oauthlib.*",
        "invenio_app.*",
        "invenio_assets.*",

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from invenio_oauthclient.views.client import auto_redirect_login
 
 from .custom_fields import *  # noqa: F401,F403
+from .utils import get_user
 
 # Flask
 # =====
@@ -113,6 +114,7 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
         }
     ],
     "publisher": "Imperial College London",
+    "creators": lambda: get_user(),
 }
 
 # See:

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from invenio_oauthclient.views.client import auto_redirect_login
 
 from .custom_fields import *  # noqa: F401,F403
-from .utils import get_user
+from .utils import get_user_form_default
 
 # Flask
 # =====
@@ -114,7 +114,7 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
         }
     ],
     "publisher": "Imperial College London",
-    "creators": lambda: get_user(),
+    "creators": lambda: get_user_form_default(),
 }
 
 # See:

--- a/site/ic_data_repo/config/utils.py
+++ b/site/ic_data_repo/config/utils.py
@@ -1,0 +1,38 @@
+"""Utilities for settings."""
+
+from typing import Any, List, Optional
+
+from flask_login import current_user
+
+
+def get_user() -> Optional[List[dict[str, Any]]]:
+    """Format the current user profile for the submission form.
+
+    The default user profile schema has two string properties;
+    full name and affiliations. More details (identifiers?) would
+    have to come from the SSO.
+    https://github.com/inveniosoftware/invenio-accounts/blob/master/invenio_accounts/profiles/schemas.py
+    """
+    affiliations = []
+
+    try:
+        name = current_user.user_profile["full_name"]
+        given_name = name.split(", ")[1]
+        family_name = name.split(", ")[0]
+    except KeyError:
+        return []
+
+    if "affiliations" in current_user.user_profile:
+        affiliations.append({"name": current_user.user_profile["affiliations"]})
+
+    return [
+        {
+            "person_or_org": {
+                "type": "personal",
+                "name": name,
+                "given_name": given_name,
+                "family_name": family_name,
+            },
+            "affiliations": affiliations,
+        },
+    ]

--- a/site/ic_data_repo/config/utils.py
+++ b/site/ic_data_repo/config/utils.py
@@ -1,11 +1,11 @@
 """Utilities for settings."""
 
-from typing import Any, List, Optional
+from typing import Any, List
 
 from flask_login import current_user
 
 
-def get_user() -> Optional[List[dict[str, Any]]]:
+def get_user_form_default() -> List[dict[str, Any]]:
     """Format the current user profile for the submission form.
 
     The default user profile schema has two string properties;


### PR DESCRIPTION
* Issue: #73 

---

This PR introduces an utility function for the settings module that formats user profile information to 
become a creator default value in the submission form.

It presupposes that a user will always be a person, and not an organisation.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
