### PR TITLE
Hide communities navigation links

### DIFF
--- a/assets/less/site/collections/menu.overrides
+++ b/assets/less/site/collections/menu.overrides
@@ -127,3 +127,15 @@
         background-color: @whiteSmoke;
     }
 }
+
+a[href="/communities"] {
+    display: none !important;
+}
+
+a[href="/communities/new"] {
+    display: none !important;
+}
+
+a[href="/me/communities"] {
+    display: none !important;
+}


### PR DESCRIPTION
* Issue: #26 
---

Somewhat hackily hides navigation items relating to communities via css.

Review requests in communities are still accessible but we'll need to provide the direct link for Wayne to use.

Follow on items we could address:
- preventing creation of new communities by blocking the url to create new communities (probably easiest via a haproxy rule).
- pre-select the imperial community for new uploads

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
