### PR TITLE
Fix striping logic for user names in oauth info_handler

### DIFF
--- a/site/ic_data_repo/auth/oauth.py
+++ b/site/ic_data_repo/auth/oauth.py
@@ -38,7 +38,7 @@ def info_handler(
         user=dict(
             email=data["email"],
             profile=dict(
-                username=data["preferred_username"].rstrip("@ic.ac.uk"),
+                username=data["preferred_username"].removesuffix("@ic.ac.uk"),
                 full_name=data["name"],
             ),
         ),


### PR DESCRIPTION
Colleague spotted this issue in another project so porting the fix over. The previous implementation would erroneously strip additional characters from the end of the username.

* Issue: 

---

*Enter a brief description of the PR contents here*

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
