### PR TITLE
Further obscure communities UI

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -4,6 +4,7 @@
 // Invenio App RDM is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
+import { Component } from "react";
 import { HiddenField } from "../../ic_data_repo/HiddenField";
 import { OptionalRoleCreatibutorsField } from "../../ic_data_repo/OptionalRoleCreatibutors";
 import { LimitedLicenseField } from "../../ic_data_repo/LimitedLicenseField";
@@ -22,6 +23,13 @@ const ContributorsField = parametrize(OptionalRoleCreatibutorsField, {
   includeRole: true,
 });
 
+/* A simple empty element to remove non-field components via override */
+class NullElement extends Component {
+  render() {
+    return null;
+  }
+}
+
 export const overriddenComponents = {
   "InvenioAppRdm.Deposit.ContributorsField.container": ContributorsField,
   "InvenioAppRdm.Deposit.CreatorsField.container": CreatorsField,
@@ -32,4 +40,6 @@ export const overriddenComponents = {
   "InvenioAppRdm.Deposit.DescriptionsField.container": TextAreaField,
   "InvenioAppRdm.Deposit.LicenseField.container": LimitedLicenseField,
   "InvenioAppRdm.Deposit.AccordionFieldReferences.container": HiddenField,
+  "InvenioAppRdm.Deposit.CommunityHeader.container": NullElement,
+  "InvenioAppRdm.DashboardUploads.EmptyResults.element": NullElement,
 };

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -17,9 +17,16 @@ and styling customisations shoud be carefully rechecked on upgrade (particularly
 
 InvenioRDM provides a feature for creating communities of deposits with an associated
 review and approval process for publication. In order to facilitate a central review
-process by the library for all deposits created a single Imperial wide community and
-have hidden references to communities in the UI. This was implemented via a style sheet
-override in [PR #97].
+process by the library for all deposits we have made use of the in-built communities
+feature. Under this model there is a single community to which all deposits are added
+and the application UI is updated to remove links and references to communities in key
+places.
+
+This has been implemented by the following changes:
+
+- Hiding UI links to pages for creating or listing communities [PR #97].
+- Updating links to create a new deposit to have the "icl" community pre-selected.
+- Hiding the communities header on the new deposit page.
 
 ### Deposit Form
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,13 @@ Direct links:
 - [ICL_OAUTH_CLIENT_ID]
 - [ICL_OAUTH_CLIENT_SECRET]
 
+### Creating deposits
+
+You will not be able to create a new upload (or access the deposit page via the UI
+links) until you have created a community to contain the records. This community must
+have the id "icl" but its other properties are unimportant. The easiest way to create a
+community is via the UI at <https://127.0.0.1:5000/communities/new>.
+
 ## Development
 
 ### QA

--- a/templates/semantic-ui/invenio_app_rdm/header_login.html
+++ b/templates/semantic-ui/invenio_app_rdm/header_login.html
@@ -46,7 +46,7 @@
 
         <div role="menu" aria-labelledby="quick-create-dropdown-btn" id="quick-create-menu" class="menu">
           {%- for item in plus_menu_items if item.visible %}
-            <a role="menuitem" class="item" href="{{ item.url }}">{{ item.text|safe }}</a>
+            <a role="menuitem" class="item" href="{{ item.url }}{% if item.url == '/uploads/new'%}?community=icl{% endif %}">{{ item.text|safe }}</a>
           {%- endfor %}
         </div>
       </div>

--- a/templates/semantic-ui/invenio_app_rdm/users/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/users/header.html
@@ -1,0 +1,41 @@
+{# -*- coding: utf-8 -*- This file is part of Invenio. Copyright (C) 2022 CERN. Invenio
+is free software; you can redistribute it and/or modify it under the terms of the MIT
+License; see LICENSE file for more details. #}
+<div class="ui container fluid page-subheader-outer shadowless with-submenu ml-0-mobile mr-0-mobile mb-0 pb-0 rel-pt-2"
+    id="dashboard-user-header-container">
+    <div class="ui container page-subheader flex justify-space-between align-items-center">
+        <div class="ui items unstackable m-0">
+            <div class="item">
+                <div class="ui image dashboard-header-avatar">
+                    <img src="{{ user_avatar }}" alt="" />
+                </div>
+                <div class="middle aligned content rel-pl-1">
+                    <h1 class="ui medium header" aria-label="{{ _('Your dashboard') }}">
+                        {{ current_userprofile.full_name or current_user.username or
+                        current_userprofile.email or _('Anonymous user')}}
+                    </h1>
+                    {% if current_userprofile.affiliations %}
+                    <div class="meta">{{ current_userprofile.affiliations }}</div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% if active_dashboard_menu_item == "uploads" %}
+        <a class="ui tiny button positive left labeled icon m-0" href="/uploads/new?community=icl">
+            <i class="upload icon" aria-hidden="true"></i>
+            {{ _('New upload') }}
+        </a>
+        {% endif %} {% if active_dashboard_menu_item == "communities" %}
+        <a class="ui tiny button positive left labeled icon m-0" href="/communities/new">
+            <i class="plus icon" aria-hidden="true"></i>
+            {{ _('New community') }}
+        </a>
+        {% endif %}
+    </div>
+    <div class="ui container secondary pointing menu page-subheader pl-0">
+        {% for item in current_menu.submenu('dashboard').children if item.visible %}
+        <a class="item {{ 'active' if active_dashboard_menu_item == item.name }} {{ 'disabled' if not item.url }}"
+            href="{{ item.url }}">{{ item.text }}</a>
+        {% endfor %}
+    </div>
+</div>


### PR DESCRIPTION
* Issue: #136
---

This PR further obscures the communities feature in the web UI by:
- Updating "new upload" ui elements to href to `/uploads/new?community=icl`.  This has the effect of pre-selecting the community into which the record will be submitted. This of course presupposes that a community with the identifier 'icl' exists. For the time being this must be created manually.
- Hiding the community header on the deposit form.
- Hiding a "new upload" element that was difficult to update in the event of a no results being returned on the user uploads list page.

Note this PR is based on the `onboarding-docs` branch (from #147) as wanted to make sure these further customisations were captured in the docs. I'll rebase it once #147 is merged.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
