### PR TITLE
Remove optional step for DOI creation

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -7,6 +7,7 @@
 import { HiddenField } from "../../ic_data_repo/HiddenField";
 import { OptionalRoleCreatibutorsField } from "../../ic_data_repo/OptionalRoleCreatibutors";
 import { LimitedLicenseField } from "../../ic_data_repo/LimitedLicenseField";
+import { MandatoryPIDField } from "../../ic_data_repo/MandatoryPIDField";
 import { parametrize } from "react-overridable";
 import { TextAreaField } from "react-invenio-forms";
 
@@ -24,6 +25,7 @@ const ContributorsField = parametrize(OptionalRoleCreatibutorsField, {
 export const overriddenComponents = {
   "InvenioAppRdm.Deposit.ContributorsField.container": ContributorsField,
   "InvenioAppRdm.Deposit.CreatorsField.container": CreatorsField,
+  "InvenioAppRdm.Deposit.PIDField.container": MandatoryPIDField,
   "InvenioAppRdm.Deposit.ResourceTypeField.container": HiddenField,
   "InvenioAppRdm.Deposit.PublisherField.container": HiddenField,
   "InvenioAppRdm.Deposit.PublicationDateField.container": HiddenField,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ module = [
        "invenio_notifications.*",
        "invenio_oauthclient.*",
        "invenio_records_resources.*",
+       "invenio_rdm_records.*",
        "marshmallow.*",
        "marshmallow_utils.*",
        ]

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/MandatoryPIDField.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/MandatoryPIDField.js
@@ -1,0 +1,351 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2023 CERN.
+// Copyright (C) 2020-2022 Northwestern University.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+import { FastField, Field, getIn } from "formik";
+import PropTypes from "prop-types";
+import React, { Component, Fragment } from "react";
+import { FieldLabel } from "react-invenio-forms";
+import { connect } from "react-redux";
+import { Form, Popup } from "semantic-ui-react";
+import {
+  DepositFormSubmitActions,
+  DepositFormSubmitContext,
+} from "@js/invenio_rdm_records/src/deposit/api/DepositFormSubmitContext";
+import { DISCARD_PID_STARTED, RESERVE_PID_STARTED } from "@js/invenio_rdm_records/src/deposit/state/types";
+
+const getFieldErrors = (form, fieldPath) => {
+  return (
+    getIn(form.errors, fieldPath, null) || getIn(form.initialErrors, fieldPath, null)
+  );
+};
+
+/**
+ * Button component to reserve a PID.
+ */
+class ReservePIDBtn extends Component {
+  render() {
+    const { disabled, handleReservePID, label, loading } = this.props;
+    return (
+      <Field>
+        {({ form: formik }) => (
+          <Form.Button
+            className="positive"
+            size="mini"
+            loading={loading}
+            disabled={disabled || loading}
+            onClick={(e) => handleReservePID(e, formik)}
+            content={label}
+          />
+        )}
+      </Field>
+    );
+  }
+}
+
+ReservePIDBtn.propTypes = {
+  disabled: PropTypes.bool,
+  handleReservePID: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+};
+
+ReservePIDBtn.defaultProps = {
+  disabled: false,
+  loading: false,
+};
+
+/**
+ * Button component to unreserve a PID.
+ */
+class UnreservePIDBtn extends Component {
+  render() {
+    const { disabled, handleDiscardPID, label, loading } = this.props;
+    return (
+      <Popup
+        content={label}
+        trigger={
+          <Field>
+            {({ form: formik }) => (
+              <Form.Button
+                disabled={disabled || loading}
+                loading={loading}
+                icon="close"
+                onClick={(e) => handleDiscardPID(e, formik)}
+                size="mini"
+              />
+            )}
+          </Field>
+        }
+      />
+    );
+  }
+}
+
+UnreservePIDBtn.propTypes = {
+  disabled: PropTypes.bool,
+  handleDiscardPID: PropTypes.func.isRequired,
+  label: PropTypes.string.isRequired,
+  loading: PropTypes.bool,
+};
+
+UnreservePIDBtn.defaultProps = {
+  disabled: false,
+  loading: false,
+};
+
+/**
+ * Render identifier field and reserve/unreserve
+ * button components for managed PID.
+ */
+class ManagedIdentifierComponent extends Component {
+  static contextType = DepositFormSubmitContext;
+
+  handleReservePID = (event, formik) => {
+    const { pidType } = this.props;
+    const { setSubmitContext } = this.context;
+    setSubmitContext(DepositFormSubmitActions.RESERVE_PID, {
+      pidType: pidType,
+    });
+    formik.handleSubmit(event);
+  };
+
+  handleDiscardPID = (event, formik) => {
+    const { pidType } = this.props;
+    const { setSubmitContext } = this.context;
+    setSubmitContext(DepositFormSubmitActions.DISCARD_PID, {
+      pidType: pidType,
+    });
+    formik.handleSubmit(event);
+  };
+
+  render() {
+    const {
+      actionState,
+      actionStateExtra,
+      btnLabelDiscardPID,
+      btnLabelGetPID,
+      disabled,
+      helpText,
+      identifier,
+      pidType,
+    } = this.props;
+    const hasIdentifier = identifier !== "";
+
+    const ReserveBtn = (
+      <ReservePIDBtn
+        disabled={disabled || hasIdentifier}
+        label={btnLabelGetPID}
+        loading={
+          actionState === RESERVE_PID_STARTED && actionStateExtra.pidType === pidType
+        }
+        handleReservePID={this.handleReservePID}
+      />
+    );
+
+    const UnreserveBtn = (
+      <UnreservePIDBtn
+        disabled={disabled}
+        label={btnLabelDiscardPID}
+        handleDiscardPID={this.handleDiscardPID}
+        loading={
+          actionState === DISCARD_PID_STARTED && actionStateExtra.pidType === pidType
+        }
+        pidType={pidType}
+      />
+    );
+
+    return (
+      <>
+        <Form.Group inline>
+          {hasIdentifier && (
+            <Form.Field>
+              <label>{identifier}</label>
+            </Form.Field>
+          )}
+
+          <Form.Field>{identifier ? UnreserveBtn : ReserveBtn}</Form.Field>
+        </Form.Group>
+        {helpText && <label className="helptext">{helpText}</label>}
+      </>
+    );
+  }
+}
+
+ManagedIdentifierComponent.propTypes = {
+  btnLabelGetPID: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  helpText: PropTypes.string,
+  identifier: PropTypes.string.isRequired,
+  btnLabelDiscardPID: PropTypes.string.isRequired,
+  pidType: PropTypes.string.isRequired,
+  /* from Redux */
+  actionState: PropTypes.string,
+  actionStateExtra: PropTypes.object,
+};
+
+ManagedIdentifierComponent.defaultProps = {
+  disabled: false,
+  helpText: null,
+  /* from Redux */
+  actionState: "",
+  actionStateExtra: {},
+};
+
+const mapStateToProps = (state) => ({
+  actionState: state.deposit.actionState,
+  actionStateExtra: state.deposit.actionStateExtra,
+});
+
+const ManagedIdentifierCmp = connect(mapStateToProps, null)(ManagedIdentifierComponent);
+
+/**
+ * Render managed or unmanaged PID fields and update
+ * Formik form on input changed.
+ * The field value has the following format:
+ * { 'doi': { identifier: '<value>', provider: '<value>', client: '<value>' } }
+ */
+class CustomPIDField extends Component {
+  constructor(props) {
+    super(props);
+    const { form } = props;
+
+    // Clear the field if the DOI is external
+    if ('doi' in form.values.pids && form.values.pids['doi'].provider === 'external') {
+        form.setFieldValue("pids", {});
+    }
+  }
+
+  render() {
+    const {
+      btnLabelDiscardPID,
+      btnLabelGetPID,
+      form,
+      fieldPath,
+      fieldLabel,
+      isEditingPublishedRecord,
+      managedHelpText,
+      pidIcon,
+      required,
+      pidType,
+      field,
+      record,
+    } = this.props;
+
+    const value = field.value || {};
+    // If we are editing an already published record.
+    const currentIdentifier = value.identifier || "";
+    const doi = record?.pids?.doi?.identifier || "";
+    const hasDoi = doi !== "";
+    const fieldError = getFieldErrors(form, fieldPath);
+
+    return (
+      <>
+        <Form.Field required={required} error={fieldError}>
+          <FieldLabel htmlFor={fieldPath} icon={pidIcon} label={fieldLabel} />
+        </Form.Field>
+
+          <ManagedIdentifierCmp
+            disabled={hasDoi && isEditingPublishedRecord}
+            btnLabelDiscardPID={btnLabelDiscardPID}
+            btnLabelGetPID={btnLabelGetPID}
+            form={form}
+            identifier={currentIdentifier}
+            helpText={managedHelpText}
+            pidType={pidType}
+          />
+
+      </>
+    );
+  }
+}
+
+CustomPIDField.propTypes = {
+  field: PropTypes.object,
+  form: PropTypes.object.isRequired,
+  btnLabelDiscardPID: PropTypes.string.isRequired,
+  btnLabelGetPID: PropTypes.string.isRequired,
+  fieldPath: PropTypes.string.isRequired,
+  fieldLabel: PropTypes.string.isRequired,
+  isEditingPublishedRecord: PropTypes.bool.isRequired,
+  managedHelpText: PropTypes.string,
+  pidIcon: PropTypes.string.isRequired,
+  pidType: PropTypes.string.isRequired,
+  required: PropTypes.bool.isRequired,
+  record: PropTypes.object.isRequired,
+};
+
+CustomPIDField.defaultProps = {
+  managedHelpText: null,
+  field: undefined,
+};
+
+
+/**
+ * Render the PIDField using a custom Formik component
+ */
+export class PIDField extends Component {
+  render() {
+    const { fieldPath } = this.props;
+    return <FastField name={fieldPath} component={CustomPIDField} {...this.props} />;
+  }
+}
+
+PIDField.propTypes = {
+  btnLabelDiscardPID: PropTypes.string,
+  btnLabelGetPID: PropTypes.string,
+  fieldPath: PropTypes.string.isRequired,
+  fieldLabel: PropTypes.string.isRequired,
+  isEditingPublishedRecord: PropTypes.bool.isRequired,
+  managedHelpText: PropTypes.string,
+  pidIcon: PropTypes.string,
+  pidType: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  record: PropTypes.object.isRequired,
+};
+
+PIDField.defaultProps = {
+  btnLabelDiscardPID: "Discard",
+  btnLabelGetPID: "Reserve",
+  managedHelpText: null,
+  pidIcon: "barcode",
+  required: false,
+};
+
+
+/**
+ * Render the PIDField using a custom Formik component
+ */
+export class MandatoryPIDField extends Component {
+  render() {
+    let { config, record } = this.props;
+
+    const pids = config.pids.map((pid) => (
+        <Fragment key={pid.scheme}>
+          <PIDField
+            btnLabelDiscardPID={pid.btn_label_discard_pid}
+            btnLabelGetPID={pid.btn_label_get_pid}
+            fieldPath={`pids.${pid.scheme}`}
+            fieldLabel={pid.field_label}
+            isEditingPublishedRecord={
+              record.is_published === true // is_published is `null` at first upload
+            }
+            managedHelpText={pid.managed_help_text}
+            pidType={pid.scheme}
+            required
+            record={record}
+          />
+        </Fragment>
+      ));
+
+    return (
+        <Fragment>
+            {pids}
+        </Fragment>
+        );
+  }
+}

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from invenio_notifications.backends.email import EmailNotificationBackend
 from invenio_oauthclient.views.client import auto_redirect_login
+from invenio_rdm_records.config import RDM_PERSISTENT_IDENTIFIERS
 
 from .custom_fields import *  # noqa: F401,F403
 from .utils import get_user_form_default
@@ -131,6 +132,9 @@ DATACITE_PASSWORD = ""
 DATACITE_PREFIX = ""
 DATACITE_TEST_MODE = True
 DATACITE_DATACENTER_SYMBOL = ""
+
+# Remove "external" as a DOI provider
+RDM_PERSISTENT_IDENTIFIERS["doi"]["providers"].remove("external")
 
 # Authentication - Invenio-Accounts and Invenio-OAuthclient
 # =========================================================


### PR DESCRIPTION
* Issue: #130

This PR replaces the [PIDField](https://github.com/inveniosoftware/invenio-rdm-records/blob/maint-10.x/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField.js) that takes care of getting a DOI for a record (as a side note, the current InvenioRDM version being developed, version 13, has refactored the PIDField component and associated components considerably).

## Default behaviour
![image](https://github.com/user-attachments/assets/c752c1c0-9440-419c-87be-28446badb303)

The default behaviour for DOIs is to allow for DOIs through Datacite or external (unmanaged) DOIs - a free text field.

![image](https://github.com/user-attachments/assets/10ded6bd-3fbf-4823-9d89-ab98d5bb9d69)

The external option is selected by default. Selecting the No radio button disables the input text field and displays a button  to "Get a DOI". Clicking the button will submit the submission form with a [RESERVE_PID action context](https://github.com/inveniosoftware/invenio-rdm-records/blob/f2cbcf223609c44c456129ce3d14e2b0a21462ad/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormSubmitContext.js#L16C16-L16C30).

![image](https://github.com/user-attachments/assets/481c8800-ed60-42f7-befd-396c485f4755)

When the form is submitted and internal PID is created, for example `d8vn9-t2z67`, but the record remains in draft form.
Another request is made to the pids endpoint: `/d8vn9-t2z67/draft/pids/doi?expand=1` and the DOI has been reserved. As far as I understand, by reserving the DOI, metadata will be uploaded to Datacite but the DOI won't be published.

## New behaviour

The notion of an externally managed DOI is removed from config (see [here](https://github.com/inveniosoftware/invenio-rdm-records/blob/f2cbcf223609c44c456129ce3d14e2b0a21462ad/invenio_rdm_records/config.py#L364)) and the hard-coded preset default values for the form are overwritten (see [here](https://github.com/inveniosoftware/invenio-app-rdm/blob/db1660030172576306ee91659bcc7dec1d6c2755/invenio_app_rdm/records_ui/views/deposits.py#L410)).

![image](https://github.com/user-attachments/assets/0c11c2b6-e368-4947-a6f0-124a02cd54d3)

![image](https://github.com/user-attachments/assets/6d137572-a2d0-4e96-af30-d055ea919552)

The user can still get and discard a DOI, regardless two DOIs will be created on publication (as DOIs are set as being mandatory in config). This form element merely allows the user to reserve a DOI and use it's value.

## Improvements
This PR can be enhanced by improving label/help text and possibly adding a copy value button. Also, adding documentation about this customisation.

I'm not sure how to approach skipping the button altogether. Submitting the form on condition on load doesn't seem straight forward and neither does overwriting the publish button, moreover, the user would not be apply to see the DOI before publication then.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
