### PR TITLE
.gitignore: Ignore VS Code config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VS Code configuration files
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
We don't want people accidentally committing these, so let's ignore VS Code config files.