### PR TITLE
Fix URLs in a couple of "new upload" buttons

### DIFF
--- a/templates/semantic-ui/invenio_app_rdm/header_login.html
+++ b/templates/semantic-ui/invenio_app_rdm/header_login.html
@@ -46,7 +46,7 @@
 
         <div role="menu" aria-labelledby="quick-create-dropdown-btn" id="quick-create-menu" class="menu">
           {%- for item in plus_menu_items if item.visible %}
-            <a role="menuitem" class="item" href="{{ item.url }}{% if item.url == '/uploads/new'%}?community=icl{% endif %}">{{ item.text|safe }}</a>
+            <a role="menuitem" class="item" href="{{ item.url }}">{{ item.text|safe }}</a>
           {%- endfor %}
         </div>
       </div>

--- a/templates/semantic-ui/invenio_app_rdm/users/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/users/header.html
@@ -21,7 +21,7 @@ License; see LICENSE file for more details. #}
             </div>
         </div>
         {% if active_dashboard_menu_item == "uploads" %}
-        <a class="ui tiny button positive left labeled icon m-0" href="/uploads/new?community=icl">
+        <a class="ui tiny button positive left labeled icon m-0" href="/uploads/new">
             <i class="upload icon" aria-hidden="true"></i>
             {{ _('New upload') }}
         </a>


### PR DESCRIPTION
There are a couple of "new upload" buttons that aren't working, one in the menu bar and one that's in the header for the uploads page. The problem seems to be that they are pointing at `/uploads/new?community=icl` which doesn't work any more.

Fix by changing the URLs to `/uploads/new`.