### PR TITLE
docker-services.yml: Use fixed hostname for postgres service

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -44,6 +44,8 @@ services:
       - "POSTGRES_USER=ic-data-repo"
       - "POSTGRES_PASSWORD=ic-data-repo"
       - "POSTGRES_DB=ic-data-repo"
+    hostname:
+      ic-data-repo-db
     ports:
       - "5432:5432"
   pgadmin:

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -3,7 +3,7 @@
     "1": {
       "Name": "ic-data-repo-db",
       "Group": "Servers",
-      "Host": "ic-data-repo-db-1",
+      "Host": "ic-data-repo-db",
       "Port": 5432,
       "MaintenanceDB": "postgres",
       "Username": "ic-data-repo",


### PR DESCRIPTION
We need a consistent hostname for the pgAdmin config file, otherwise developers won't be able to use it to access their local dev database.

Fixes #163.