### PR TITLE
Use logger for messages related to importing ICL users

### DIFF
--- a/app_data/imperial-names-vocab.yaml
+++ b/app_data/imperial-names-vocab.yaml
@@ -8,3 +8,5 @@ names:
         origin: "/dev/stdin"
   writers:
     - type: names-service
+      args:
+        update: true

--- a/app_data/import_imperial_users.py
+++ b/app_data/import_imperial_users.py
@@ -21,4 +21,4 @@ if __name__ == "__main__":
     # Let user specify max number of users to retrieve so they can things without
     # loading the lot
     max_count = int(sys.argv[1]) if len(sys.argv) > 1 else None
-    import_imperial_contributors_to_invenio(client, max_count)
+    import_imperial_contributors_to_invenio(client, max_count=max_count)

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -251,8 +251,12 @@ def import_imperial_contributors_to_invenio(
     logger.info(f"Loaded {len(users)} possible contributors.")
 
     logger.info("Adding names to Invenio")
-    _add_names_to_invenio(users, logger)
-    logger.info("Added names.")
+    already_existing = _add_names_to_invenio(users, logger)
+    if already_existing > 0:
+        logger.warning(
+            f"WARNING: {already_existing}/{len(users)} users already exist in database."
+        )
+    logger.info("Finished importing Imperial users.")
 
 
 def _get_invenio_path() -> str:
@@ -263,7 +267,7 @@ def _get_invenio_path() -> str:
     return path
 
 
-def _add_names_to_invenio(users: list[ImperialUser], logger: Logger):
+def _add_names_to_invenio(users: list[ImperialUser], logger: Logger) -> int:
     """Add the specified Imperial users to the names vocab."""
     # Path to invenio program
     invenio_path = _get_invenio_path()
@@ -290,8 +294,14 @@ def _add_names_to_invenio(users: list[ImperialUser], logger: Logger):
 
     # Print contents of stdout and stderr with logger
     stdout = process.communicate(names_str)[0]
+    already_existing = 0
     for line in stdout.splitlines():
-        logger.info(f"invenio: {line}")
+        if line.startswith('NamesServiceWriter: ["Vocabulary entry already exists:'):
+            already_existing += 1
+        else:
+            logger.info(f"invenio: {line}")
 
     if process.returncode != 0:
         raise RuntimeError(f"invenio process exited with code {process.returncode}")
+
+    return already_existing

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -48,8 +48,10 @@ There are also many users with no job family specified.
 """
 
 import asyncio
+import logging
 import subprocess as sp
 from dataclasses import dataclass
+from logging import Logger
 from pathlib import Path
 from shutil import which
 from typing import Any, AsyncIterable, Iterable, Optional
@@ -101,6 +103,16 @@ _ICL_ROR_ID = "041kmwe10"
 """The ROR identifier for Imperial."""
 
 _QueryParameters = UsersRequestBuilder.UsersRequestBuilderGetQueryParameters
+
+
+def _get_default_logger() -> Logger:
+    """Get a default logger for this module which just prints to stdout."""
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    logger.addHandler(ch)
+    return logger
 
 
 @dataclass
@@ -229,16 +241,18 @@ def _get_request_config_for_roles(
 
 
 def import_imperial_contributors_to_invenio(
-    client: GraphServiceClient, max_count: Optional[int] = None
+    client: GraphServiceClient,
+    logger: Logger = _get_default_logger(),
+    max_count: Optional[int] = None,
 ) -> None:
     """Import Imperial users which are possible contributors into the names vocab."""
-    print("Importing Imperial users...")
+    logger.info("Importing Imperial users...")
     users = asyncio.run(get_possible_imperial_contributors(client, max_count))
-    print(f"Loaded {len(users)} possible contributors.")
+    logger.info(f"Loaded {len(users)} possible contributors.")
 
-    print("Adding names to Invenio")
+    logger.info("Adding names to Invenio")
     _add_names_to_invenio(users)
-    print("Added names.")
+    logger.info("Added names.")
 
 
 def _get_invenio_path() -> str:

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -251,7 +251,7 @@ def import_imperial_contributors_to_invenio(
     logger.info(f"Loaded {len(users)} possible contributors.")
 
     logger.info("Adding names to Invenio")
-    _add_names_to_invenio(users)
+    _add_names_to_invenio(users, logger)
     logger.info("Added names.")
 
 
@@ -263,7 +263,7 @@ def _get_invenio_path() -> str:
     return path
 
 
-def _add_names_to_invenio(users: list[ImperialUser]):
+def _add_names_to_invenio(users: list[ImperialUser], logger: Logger):
     """Add the specified Imperial users to the names vocab."""
     # Path to invenio program
     invenio_path = _get_invenio_path()
@@ -272,7 +272,7 @@ def _add_names_to_invenio(users: list[ImperialUser]):
     names_str = yaml.dump(
         list(user.as_invenio_record() for user in users), sort_keys=False
     )
-    sp.run(
+    process = sp.Popen(
         [
             invenio_path,
             "vocabularies",
@@ -282,6 +282,16 @@ def _add_names_to_invenio(users: list[ImperialUser]):
             "--filepath",
             str(_NAMES_VOCAB_PATH),
         ],
-        input=names_str.encode(),
-        check=True,
+        stdin=sp.PIPE,
+        stdout=sp.PIPE,
+        stderr=sp.STDOUT,
+        text=True,
     )
+
+    # Print contents of stdout and stderr with logger
+    stdout = process.communicate(names_str)[0]
+    for line in stdout.splitlines():
+        logger.info(f"invenio: {line}")
+
+    if process.returncode != 0:
+        raise RuntimeError(f"invenio process exited with code {process.returncode}")

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -107,11 +107,8 @@ _QueryParameters = UsersRequestBuilder.UsersRequestBuilderGetQueryParameters
 
 def _get_default_logger() -> Logger:
     """Get a default logger for this module which just prints to stdout."""
+    logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.INFO)
-    logger.addHandler(ch)
     return logger
 
 

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -107,8 +107,11 @@ _QueryParameters = UsersRequestBuilder.UsersRequestBuilderGetQueryParameters
 
 def _get_default_logger() -> Logger:
     """Get a default logger for this module which just prints to stdout."""
-    logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    logger.addHandler(ch)
     return logger
 
 

--- a/site/ic_data_repo/import_imperial_users.py
+++ b/site/ic_data_repo/import_imperial_users.py
@@ -248,12 +248,8 @@ def import_imperial_contributors_to_invenio(
     logger.info(f"Loaded {len(users)} possible contributors.")
 
     logger.info("Adding names to Invenio")
-    already_existing = _add_names_to_invenio(users, logger)
-    if already_existing > 0:
-        logger.warning(
-            f"WARNING: {already_existing}/{len(users)} users already exist in database."
-        )
-    logger.info("Finished importing Imperial users.")
+    _add_names_to_invenio(users, logger)
+    logger.info("Added names.")
 
 
 def _get_invenio_path() -> str:
@@ -264,7 +260,7 @@ def _get_invenio_path() -> str:
     return path
 
 
-def _add_names_to_invenio(users: list[ImperialUser], logger: Logger) -> int:
+def _add_names_to_invenio(users: list[ImperialUser], logger: Logger):
     """Add the specified Imperial users to the names vocab."""
     # Path to invenio program
     invenio_path = _get_invenio_path()
@@ -291,14 +287,8 @@ def _add_names_to_invenio(users: list[ImperialUser], logger: Logger) -> int:
 
     # Print contents of stdout and stderr with logger
     stdout = process.communicate(names_str)[0]
-    already_existing = 0
     for line in stdout.splitlines():
-        if line.startswith('NamesServiceWriter: ["Vocabulary entry already exists:'):
-            already_existing += 1
-        else:
-            logger.info(f"invenio: {line}")
+        logger.info(f"invenio: {line}")
 
     if process.returncode != 0:
         raise RuntimeError(f"invenio process exited with code {process.returncode}")
-
-    return already_existing


### PR DESCRIPTION
I was working on this as a precursor to #157 and figured it probably deserved its own PR.

The current implementation of the code to import ICL users prints out information to stdout/stderr in a couple of places:

1. There are some `print` statements in `import_imperial_contributors_to_invenio`
2. When we run the `invenio` CLI command via `subprocess.run` the contents of its `stdout` and `stderr` are written to the console

I figured it would be better to write this information to a log so that it doesn't get lost when we are running it as a Celery task. Interestingly, when I tried running it via Celery, the `print` statements *were* logged correctly (it must intercept them somehow), but not the stdout/stderr of the `invenio` process. So this would be an alternative approach: just `print()` the information instead.

As it is, I've gone with adding a `logger` argument to `import_imperial_contributors_to_invenio`. Not sure if this is best practice or whether it would be better to just configure a logger for the module, then when we come to hook it up to Celery, we could add a handler to it to redirect output to `flask.current_app.logger`. Thoughts welcome.

Another problem I wanted to fix was that we get messages like this when trying to import users that already exist:

```
NamesServiceWriter: ["Vocabulary entry already exists: {'family_name': 'Higginson', 'given_name': 'James Anthony', 'id': 'jah119', 'affiliations': [{'id': '041kmwe10'}]}"]
NamesServiceWriter: ["Vocabulary entry already exists: {'family_name': 'Hopper', 'given_name': 'Phoebe', 'id': 'phopper', 'affiliations': [{'id': '041kmwe10'}]}"]
NamesServiceWriter: ["Vocabulary entry already exists: {'family_name': 'Galaz Souza', 'given_name': 'Natalia', 'id': 'ng1016', 'affiliations': [{'id': '041kmwe10'}]}"]
```

Note that this means we'll get one of these *per user* every time we run the import in production, which will fill the log with spam. I wrote a horrid hack that filters out these messages and gives a count at the end.

There is an `invenio vocabularies update` command which sounds like it should do what we want, but when I tried running it I got this informative error message:

```
❯ invenio vocabularies update -v names -f imperial-names-vocab.yaml
Traceback (most recent call last):
  File "/home/alex/code/fair-data-repository/.venv/bin/invenio", line 8, in <module>
    sys.exit(cli())
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/flask/cli.py", line 357, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/alex/code/fair-data-repository/.venv/lib/python3.9/site-packages/invenio_vocabularies/cli.py", line 134, in update
    w_conf["args"]["update"] = True
KeyError: 'args'
```

It might be worth digging into this at some point as I can imagine people's names etc. might change and it'd be nice to be able to update their records properly, especially seeing as we're downloading all that data from Azure anyway.