### PR TITLE
Periodically repopulate names vocabulary with Imperial users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ data/.minio.sys
 
 # Celery
 celerybeat-schedule
+celerybeat-schedule.db
 
 # test datasets
 test_data/10.14469_hpc_*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ exclude = "test_data/.*\\.py"
 
 [[tool.mypy.overrides]]
 module = [
+       "celery.*",
        "flask_login.*",
        "flask_oauthlib.*",
        "invenio_app.*",
+       "invenio_app_rdm.config.*",
        "invenio_assets.*",
        "invenio_i18n.*",
        "invenio_notifications.*",
@@ -30,7 +32,7 @@ module = [
        "marshmallow.*",
        "marshmallow_utils.*",
        "testcontainers.*",
-       ]
+]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -7,9 +7,10 @@ https://inveniordm.docs.cern.ch/reference/configuration/.
 """
 
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import invenio_rdm_records
+from invenio_app_rdm.config import CELERY_BEAT_SCHEDULE
 from invenio_notifications.backends.email import EmailNotificationBackend
 from invenio_oauthclient.views.client import auto_redirect_login
 from invenio_rdm_records.config import RDM_PERSISTENT_IDENTIFIERS
@@ -233,4 +234,11 @@ RDM_ALLOW_METADATA_ONLY_RECORDS = False
 
 NOTIFICATION_BACKENDS = {
     EmailNotificationBackend.id: EmailNotificationBackend,
+}
+
+# Periodic tasks
+# --------------
+CELERY_BEAT_SCHEDULE["update_imperial_users"] = {
+    "task": "ic_data_repo.tasks.update_imperial_users",
+    "schedule": timedelta(weeks=1),
 }

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -21,7 +21,7 @@ def update_imperial_users() -> None:
     """Update the list of possible contributors from Imperial."""
     if not ICL_OAUTH_CLIENT_ID or not ICL_OAUTH_CLIENT_SECRET:
         raise RuntimeError(
-            "ICL_OAUTH_CLIENT_ID and ICL_OAUTH_CLIENT secret env vars must be set"
+            "ICL_OAUTH_CLIENT_ID and ICL_OAUTH_CLIENT_SECRET env vars must be set"
         )
 
     client = get_client(

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -1,0 +1,4 @@
+"""Tasks to be run by celery.
+
+In particular, this includes tasks to be run periodically in the background.
+"""

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -2,3 +2,24 @@
 
 In particular, this includes tasks to be run periodically in the background.
 """
+
+from celery import shared_task
+from flask import current_app
+from ic_data_repo.config import (
+    ICL_MICROSOFT_TENANT_ID,
+    ICL_OAUTH_CLIENT_ID,
+    ICL_OAUTH_CLIENT_SECRET,
+)
+from ic_data_repo.import_imperial_users import (
+    get_client,
+    import_imperial_contributors_to_invenio,
+)
+
+
+@shared_task
+def update_imperial_users() -> None:
+    """Update the list of possible contributors from Imperial."""
+    client = get_client(
+        ICL_MICROSOFT_TENANT_ID, ICL_OAUTH_CLIENT_ID, ICL_OAUTH_CLIENT_SECRET
+    )
+    import_imperial_contributors_to_invenio(client, current_app.logger)

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -19,6 +19,11 @@ from ic_data_repo.import_imperial_users import (
 @shared_task
 def update_imperial_users() -> None:
     """Update the list of possible contributors from Imperial."""
+    if not ICL_OAUTH_CLIENT_ID or not ICL_OAUTH_CLIENT_SECRET:
+        raise RuntimeError(
+            "ICL_OAUTH_CLIENT_ID and ICL_OAUTH_CLIENT secret env vars must be set"
+        )
+
     client = get_client(
         ICL_MICROSOFT_TENANT_ID, ICL_OAUTH_CLIENT_ID, ICL_OAUTH_CLIENT_SECRET
     )

--- a/site/setup.cfg
+++ b/site/setup.cfg
@@ -11,3 +11,5 @@ invenio_base.blueprints =
     ic_data_repo_views = ic_data_repo.views:create_blueprint
 invenio_assets.webpack =
     ic_data_repo_theme = ic_data_repo.webpack:theme
+invenio_celery.tasks =
+    ic_data_repo_tasks = ic_data_repo.tasks


### PR DESCRIPTION
This PR builds off previous work to import Imperial users to the list of suggested contributors for new datasets. It adds a task to repopulate the list (the "names vocabulary" in Invenio speak) once a week to the Celery schedule. The way this is implemented doesn't really resemble what [the Invenio docs](https://invenio-celery.readthedocs.io/en/latest/usage.html#periodic-tasks) suggest you do -- presumably they're just out of date.

Periodic tasks appear not to run on startup (presumably just after the specified delay), but I hacked the code to run the task manually and have confirmed that it does what it's supposed to. I haven't written tests though -- but I can if that's something we'd like.

Closes #157.