### PR TITLE
Add deposit agreement checkbox

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -11,6 +11,7 @@ import { LimitedLicenseField } from "../../ic_data_repo/LimitedLicenseField";
 import { MandatoryPIDField } from "../../ic_data_repo/MandatoryPIDField";
 import { parametrize } from "react-overridable";
 import { TextAreaField } from "react-invenio-forms";
+import { CardDepositStatusBox } from "../../ic_data_repo/CardDepositStatusBox";
 
 const CreatorsField = parametrize(OptionalRoleCreatibutorsField, {
   helpText: "The main individuals or institutions involved in creating the data set.",
@@ -42,4 +43,5 @@ export const overriddenComponents = {
   "InvenioAppRdm.Deposit.AccordionFieldReferences.container": HiddenField,
   "InvenioAppRdm.Deposit.CommunityHeader.container": NullElement,
   "InvenioAppRdm.DashboardUploads.EmptyResults.element": NullElement,
+  "InvenioAppRdm.Deposit.CardDepositStatusBox.container": CardDepositStatusBox,
 };

--- a/docs/customisation.md
+++ b/docs/customisation.md
@@ -28,9 +28,9 @@ This has been implemented by the following changes:
 - Updating links to create a new deposit to have the "icl" community pre-selected.
 - Hiding the communities header on the new deposit page.
 
-### Deposit Form
+### Deposit Page
 
-Some changes to the deposit form have made use of the support in InvenioRDM for
+Some changes to the deposit page have made use of the support in InvenioRDM for
 overriding React components. See [InvenioRDM Docs: How to override UI React components]
 for more details. Overriden components are stored in
 `assets/js/invenio_app_rdm/overridableRegistry/mapping.js`. In summary:
@@ -57,6 +57,9 @@ for more details. Overriden components are stored in
     the `OptionalRoleCreatibutorsField` this required extensive copy-pasting of the
     original [LicensesField] component so the same checks and changes should be applied
     on update of `invenio-rdm-records`.
+- A checkbox for the data deposit agreement has been added to the modal created by the
+    `Submit For Review` button. This checkbox is required to be checked before the user
+    can submit their data for review.
 
 Other customisations have used the [APP_RDM_DEPOSIT_FORM_DEFAULTS] setting (set in
 `site/ic_data_repo/config/settings.py`). In summary:

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/CardDepositStatusBox.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/CardDepositStatusBox.js
@@ -1,0 +1,54 @@
+import React, { Component } from "react";
+import { Card, Container, Grid, Ref, Sticky } from "semantic-ui-react";
+import { DepositStatusBox, PreviewButton, SaveButton } from "@js/invenio_rdm_records";
+import PropTypes from "prop-types";
+import { ShareDraftButton } from "@js/invenio_app_rdm/deposit/ShareDraftButton";
+import { PublishButton } from "./PublishButton";
+
+export class CardDepositStatusBox extends Component {
+  render() {
+    const { record, permissions, groupsEnabled } = this.props;
+    return (
+      <Card>
+        <Card.Content>
+          <DepositStatusBox />
+        </Card.Content>
+        <Card.Content>
+          <Grid relaxed>
+            <Grid.Column computer={8} mobile={16} className="pb-0 left-btn-col">
+              <SaveButton fluid />
+            </Grid.Column>
+
+            <Grid.Column computer={8} mobile={16} className="pb-0 right-btn-col">
+              <PreviewButton fluid />
+            </Grid.Column>
+
+            <Grid.Column width={16} className="pt-10">
+              <PublishButton fluid record={record} />
+            </Grid.Column>
+
+            <Grid.Column width={16} className="pt-0">
+              {(record.is_draft === null || permissions.can_manage) && (
+                <ShareDraftButton
+                  record={record}
+                  permissions={permissions}
+                  groupsEnabled={groupsEnabled}
+                />
+              )}
+            </Grid.Column>
+          </Grid>
+        </Card.Content>
+      </Card>
+    );
+  }
+}
+
+CardDepositStatusBox.propTypes = {
+  record: PropTypes.object.isRequired,
+  permissions: PropTypes.object,
+  groupsEnabled: PropTypes.bool.isRequired,
+};
+
+CardDepositStatusBox.defaultProps = {
+  permissions: null,
+};

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewButton.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewButton.js
@@ -1,0 +1,168 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2023 CERN.
+// Copyright (C) 2020-2022 Northwestern University.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+import { connect as connectFormik } from "formik";
+import _get from "lodash/get";
+import _omit from "lodash/omit";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Button } from "semantic-ui-react";
+import {
+  DepositFormSubmitActions,
+  DepositFormSubmitContext,
+} from "@js/invenio_rdm_records/src/deposit/api/DepositFormSubmitContext";
+import { DepositStatus } from "@js/invenio_rdm_records/src/deposit/state/reducers/deposit";
+import { DepositAgreementSubmitReviewModal } from "./SubmitReviewModal";
+
+class SubmitReviewButtonComponent extends Component {
+  state = { isConfirmModalOpen: false };
+  static contextType = DepositFormSubmitContext;
+
+  openConfirmModal = () => this.setState({ isConfirmModalOpen: true });
+
+  closeConfirmModal = () => this.setState({ isConfirmModalOpen: false });
+
+  handleSubmitReview = ({ reviewComment }) => {
+    const { formik, directPublish } = this.props;
+    const { handleSubmit } = formik;
+    const { setSubmitContext } = this.context;
+
+    setSubmitContext(DepositFormSubmitActions.SUBMIT_REVIEW, {
+      reviewComment,
+      directPublish,
+    });
+    handleSubmit();
+    this.closeConfirmModal();
+  };
+
+  isDisabled = (disableSubmitForReviewButton, filesState) => {
+    const { formik, userCanManageRecord, record } = this.props;
+    const { values, isSubmitting } = formik;
+
+    // record is coming from the Jinja template and it is refreshed on page reload
+    const isNewUpload = !record.id;
+    // Check if the user can manage the record only if it is not a new upload
+    if (
+      (!isNewUpload && !userCanManageRecord) ||
+      disableSubmitForReviewButton ||
+      isSubmitting
+    ) {
+      return true;
+    }
+
+    const filesEnabled = _get(values, "files.enabled", false);
+    const filesArray = Object.values(filesState.entries ?? {});
+    const filesMissing = filesEnabled && filesArray.length === 0;
+
+    if (filesMissing) {
+      return true;
+    }
+
+    // All files must be finished uploading
+    const allCompleted = filesArray.every((file) => file.status === "finished");
+
+    return !allCompleted;
+  };
+
+  render() {
+    const {
+      actionState,
+      actionStateExtra,
+      community,
+      disableSubmitForReviewButton,
+      directPublish,
+      formik,
+      isRecordSubmittedForReview,
+      publishModalExtraContent,
+      filesState,
+      ...ui
+    } = this.props;
+
+    const { isSubmitting } = formik;
+
+    const uiProps = _omit(ui, ["dispatch"]);
+
+    const { isConfirmModalOpen } = this.state;
+
+    const btnLblSubmitReview = isRecordSubmittedForReview
+      ? i18next.t("Submitted for review")
+      : i18next.t("Submit for review");
+    const buttonLbl = directPublish
+      ? i18next.t("Publish to community")
+      : btnLblSubmitReview;
+
+    return (
+      <>
+        <Button
+          disabled={this.isDisabled(disableSubmitForReviewButton, filesState)}
+          name="SubmitReview"
+          onClick={this.openConfirmModal}
+          positive={directPublish}
+          primary={!directPublish}
+          icon="upload"
+          loading={isSubmitting && actionState === "DRAFT_SUBMIT_REVIEW_STARTED"}
+          labelPosition="left"
+          content={buttonLbl}
+          {...uiProps}
+          type="button" // needed so the formik form doesn't handle it as submit button i.e enable HTML validation on required input fields
+        />
+        {isConfirmModalOpen && (
+          <DepositAgreementSubmitReviewModal
+            isConfirmModalOpen={isConfirmModalOpen}
+            initialReviewComment={actionStateExtra.reviewComment}
+            onSubmit={this.handleSubmitReview}
+            community={community}
+            onClose={this.closeConfirmModal}
+            publishModalExtraContent={publishModalExtraContent}
+            directPublish={directPublish}
+          />
+        )}
+      </>
+    );
+  }
+}
+
+SubmitReviewButtonComponent.propTypes = {
+  actionState: PropTypes.string,
+  actionStateExtra: PropTypes.object.isRequired,
+  community: PropTypes.object.isRequired,
+  disableSubmitForReviewButton: PropTypes.bool,
+  isRecordSubmittedForReview: PropTypes.bool.isRequired,
+  directPublish: PropTypes.bool,
+  formik: PropTypes.object.isRequired,
+  publishModalExtraContent: PropTypes.string,
+  filesState: PropTypes.object,
+  userCanManageRecord: PropTypes.bool.isRequired,
+  record: PropTypes.object.isRequired,
+};
+
+SubmitReviewButtonComponent.defaultProps = {
+  actionState: undefined,
+  disableSubmitForReviewButton: undefined,
+  publishModalExtraContent: undefined,
+  directPublish: false,
+  filesState: undefined,
+};
+
+const mapStateToProps = (state) => ({
+  actionState: state.deposit.actionState,
+  actionStateExtra: state.deposit.actionStateExtra,
+  community: state.deposit.editorState.selectedCommunity,
+  isRecordSubmittedForReview: state.deposit.record.status === DepositStatus.IN_REVIEW,
+  disableSubmitForReviewButton:
+    state.deposit.editorState.ui.disableSubmitForReviewButton,
+  publishModalExtraContent: state.deposit.config.publish_modal_extra,
+  filesState: state.files,
+  userCanManageRecord: state.deposit.permissions.can_manage,
+});
+
+export const SubmitReviewButton = connect(
+  mapStateToProps,
+  null,
+)(connectFormik(SubmitReviewButtonComponent));

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewModal.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewModal.js
@@ -1,0 +1,261 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2023 CERN.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+import { Formik } from "formik";
+import _get from "lodash/get";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { Trans } from "react-i18next";
+import {
+  ErrorLabel,
+  RadioField,
+  TextAreaField,
+  ErrorMessage,
+} from "react-invenio-forms";
+import { Button, Checkbox, Form, Icon, Message, Modal } from "semantic-ui-react";
+import * as Yup from "yup";
+import { SubmitReviewModal } from "@js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewModal";
+
+export class DepositAgreementSubmitReviewModal extends SubmitReviewModal {
+  ConfirmSubmitReviewSchema = Yup.object({
+    acceptAccessToRecord: Yup.bool().oneOf([true], i18next.t("You must accept this.")),
+    reviewComment: Yup.string(),
+    // Validation for additional checkbox
+    depositAgreement: Yup.bool().oneOf([true], i18next.t("You must accept this.")),
+  });
+
+  render() {
+    const {
+      initialReviewComment,
+      isConfirmModalOpen,
+      community,
+      onClose,
+      onSubmit,
+      publishModalExtraContent,
+      directPublish,
+      errors,
+      loading,
+      record,
+    } = this.props;
+    const communityTitle = community.metadata.title;
+
+    const directPublishCase = () => {
+      headerTitle = i18next.t("Publish to community");
+      msgWarningTitle = i18next.t(
+        "Before publishing to the community, please read and check the following:",
+      );
+      msgWarningText1 = i18next.t(
+        "Your upload will be <bold>immediately published</bold> in '{{communityTitle}}'. You will no longer be able to change the files in the upload! However, you will still be able to update the record's metadata later.",
+        { communityTitle },
+      );
+      submitBtnLbl = i18next.t("Publish record to community");
+    };
+
+    let headerTitle, msgWarningTitle, msgWarningText1, submitBtnLbl;
+    // if record is passed and it is published
+    if (record?.is_published) {
+      headerTitle = i18next.t("Submit to community");
+      msgWarningTitle = i18next.t(
+        "Before submitting to community, please read and check the following:",
+      );
+      submitBtnLbl = i18next.t("Submit to community");
+    }
+    // else record is a draft
+    else {
+      if (directPublish) {
+        directPublishCase();
+      } else {
+        headerTitle = i18next.t("Submit for review");
+        msgWarningTitle = i18next.t(
+          "Before requesting review, please read and check the following:",
+        );
+        msgWarningText1 = i18next.t(
+          "If your upload is accepted by the community curators, it will be <bold>immediately published</bold>. Before that, you will still be able to modify metadata and files of this upload.",
+        );
+        submitBtnLbl = i18next.t("Submit record for review");
+      }
+    }
+
+    // acceptAfterPublishRecord checkbox is absent if record is published
+    const schema = () => {
+      if (record) {
+        return this.ConfirmSubmitReviewSchema;
+      } else {
+        const additionalValidationSchema = Yup.object({
+          acceptAfterPublishRecord: Yup.bool().oneOf(
+            [true],
+            i18next.t("You must accept this."),
+          ),
+        });
+        return this.ConfirmSubmitReviewSchema.concat(additionalValidationSchema);
+      }
+    };
+
+    return (
+      <Formik
+        initialValues={{
+          acceptAccessToRecord: false,
+          acceptAfterPublishRecord: false,
+          depositAgreement: false,
+          reviewComment: initialReviewComment || "",
+        }}
+        onSubmit={onSubmit}
+        validationSchema={schema}
+        validateOnChange={false}
+        validateOnBlur={false}
+      >
+        {({ values, handleSubmit }) => {
+          return (
+            <Modal
+              open={isConfirmModalOpen}
+              onClose={onClose}
+              size="small"
+              closeIcon
+              closeOnDimmerClick={false}
+            >
+              <Modal.Header>{headerTitle}</Modal.Header>
+              <Modal.Content>
+                {errors && <ErrorMessage errors={errors} />}
+                <Message visible warning>
+                  <p>
+                    <Icon name="warning sign" />
+                    {msgWarningTitle}
+                  </p>
+                </Message>
+                <Form>
+                  <Form.Field id="accept-access-checkbox">
+                    <RadioField
+                      control={Checkbox}
+                      fieldPath="acceptAccessToRecord"
+                      label={
+                        <Trans
+                          defaults={i18next.t(
+                            "The '{{communityTitle}}' curators will have access to <bold>view</bold> and <bold>edit</bold> your upload's metadata and files.",
+                            { communityTitle },
+                          )}
+                          values={{
+                            communityTitle,
+                          }}
+                          components={{ bold: <b /> }}
+                          shouldUnescape
+                        />
+                      }
+                      checked={_get(values, "acceptAccessToRecord") === true}
+                      onChange={({ data, formikProps }) => {
+                        formikProps.form.setFieldValue(
+                          "acceptAccessToRecord",
+                          data.checked,
+                        );
+                      }}
+                      optimized
+                    />
+                    <ErrorLabel
+                      role="alert"
+                      fieldPath="acceptAccessToRecord"
+                      className="mt-0 mb-5"
+                    />
+                  </Form.Field>
+                  {!record && (
+                    <Form.Field>
+                      <RadioField
+                        control={Checkbox}
+                        fieldPath="acceptAfterPublishRecord"
+                        label={
+                          <Trans
+                            defaults={msgWarningText1}
+                            values={{
+                              communityTitle: communityTitle,
+                            }}
+                            components={{ bold: <b /> }}
+                          />
+                        }
+                        checked={_get(values, "acceptAfterPublishRecord") === true}
+                        onChange={({ data, formikProps }) => {
+                          formikProps.form.setFieldValue(
+                            "acceptAfterPublishRecord",
+                            data.checked,
+                          );
+                        }}
+                        optimized
+                      />
+                      <ErrorLabel
+                        role="alert"
+                        fieldPath="acceptAfterPublishRecord"
+                        className="mt-0 mb-5"
+                      />
+                    </Form.Field>
+                  )}
+                  {/* Additional checkbox */}
+                  <Form.Field id="deposit-agreement-checkbox">
+                    <RadioField
+                      control={Checkbox}
+                      fieldPath="depositAgreement"
+                      label={
+                        <Trans
+                          defaults={i18next.t(
+                            "This submissions meets the requirements of the Data Deposit Agreement.",
+                          )}
+                          shouldUnescape
+                        />
+                      }
+                      checked={_get(values, "depositAgreement") === true}
+                      onChange={({ data, formikProps }) => {
+                        formikProps.form.setFieldValue(
+                          "depositAgreement",
+                          data.checked,
+                        );
+                      }}
+                      optimized
+                    />
+                    <ErrorLabel
+                      role="alert"
+                      fieldPath="depositAgreement"
+                      className="mt-0 mb-5"
+                    />
+                  </Form.Field>
+                  {!directPublish && (
+                    <TextAreaField
+                      fieldPath="reviewComment"
+                      label={i18next.t("Message to curators (optional)")}
+                    />
+                  )}
+
+                  {publishModalExtraContent && (
+                    <div
+                      dangerouslySetInnerHTML={{ __html: publishModalExtraContent }}
+                    />
+                  )}
+                </Form>
+              </Modal.Content>
+              <Modal.Actions>
+                <Button
+                  onClick={onClose}
+                  floated="left"
+                  loading={loading}
+                  disabled={loading}
+                >
+                  {i18next.t("Cancel")}
+                </Button>
+                <Button
+                  name="submitReview"
+                  onClick={(event) => {
+                    handleSubmit(event);
+                  }}
+                  loading={loading}
+                  disabled={loading}
+                  positive={directPublish}
+                  primary={!directPublish}
+                  content={submitBtnLbl}
+                />
+              </Modal.Actions>
+            </Modal>
+          );
+        }}
+      </Formik>
+    );
+  }
+}

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewOrPublishButton.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/SubmitReviewOrPublishButton.js
@@ -1,0 +1,107 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2022-2023 CERN.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { Button } from "semantic-ui-react";
+import { changeSelectedCommunity } from "@js/invenio_rdm_records/src/deposit/state/actions";
+import { CommunitySelectionModal } from "@js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal";
+// import { PublishButton } from "./PublishButton";
+// import { SubmitReviewButton } from "./SubmitReviewButton";
+import { PublishButton } from "@js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton";
+import { SubmitReviewButton } from "./SubmitReviewButton";
+
+class SubmitReviewOrPublishComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      modalOpen: false,
+    };
+  }
+  render() {
+    const {
+      community,
+      changeSelectedCommunityFn,
+      showChangeCommunityButton,
+      showDirectPublishButton,
+      showSubmitForReviewButton,
+      record,
+      ...ui
+    } = this.props;
+    const { modalOpen } = this.state;
+    let result;
+
+    if (showSubmitForReviewButton) {
+      result = (
+        <SubmitReviewButton
+          directPublish={showDirectPublishButton}
+          {...ui}
+          fluid
+          className="mb-10"
+          record={record}
+        />
+      );
+    } else if (showChangeCommunityButton) {
+      result = (
+        <>
+          <CommunitySelectionModal
+            onCommunityChange={(community) => {
+              changeSelectedCommunityFn(community);
+            }}
+            onModalChange={(value) => this.setState({ modalOpen: value })}
+            modalOpen={modalOpen}
+            displaySelected
+            record={record}
+            chosenCommunity={community}
+            trigger={
+              <Button content={i18next.t("Change community")} fluid className="mb-10" />
+            }
+          />
+          <PublishButton
+            buttonLabel={i18next.t("Publish without community")}
+            publishWithoutCommunity
+            {...ui}
+          />
+        </>
+      );
+    } else {
+      result = <PublishButton {...ui} />;
+    }
+    return result;
+  }
+}
+
+SubmitReviewOrPublishComponent.propTypes = {
+  community: PropTypes.object,
+  changeSelectedCommunityFn: PropTypes.func.isRequired,
+  showChangeCommunityButton: PropTypes.bool.isRequired,
+  showDirectPublishButton: PropTypes.bool.isRequired,
+  showSubmitForReviewButton: PropTypes.bool.isRequired,
+  record: PropTypes.object.isRequired,
+};
+
+SubmitReviewOrPublishComponent.defaultProps = {
+  community: undefined,
+};
+
+const mapStateToProps = (state) => ({
+  community: state.deposit.editorState.selectedCommunity,
+  showDirectPublishButton: state.deposit.editorState.ui.showDirectPublishButton,
+  showChangeCommunityButton: state.deposit.editorState.ui.showChangeCommunityButton,
+  showSubmitForReviewButton: state.deposit.editorState.ui.showSubmitForReviewButton,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  changeSelectedCommunityFn: (community) =>
+    dispatch(changeSelectedCommunity(community)),
+});
+
+export const SubmitReviewOrPublishButton = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SubmitReviewOrPublishComponent);

--- a/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/index.js
+++ b/site/ic_data_repo/assets/semantic-ui/js/ic_data_repo/PublishButton/index.js
@@ -1,0 +1,1 @@
+export { SubmitReviewOrPublishButton as PublishButton } from "./SubmitReviewOrPublishButton";


### PR DESCRIPTION
Fixes #201 

Adds a checkbox to the modal displayed to users when they submit their deposit for review. Unfortunately, as with other UI elements, you have to override and copy the source of a number of higher level components to get access to the bit you want to tweak.