### PR TITLE
Add script to create the imperial community

### DIFF
--- a/app_data/create_imperial_community.py
+++ b/app_data/create_imperial_community.py
@@ -1,0 +1,23 @@
+"""Script to create_app Imperial Community."""
+
+from invenio_access.permissions import system_identity
+from invenio_app.factory import create_app
+from invenio_communities.proxies import current_communities
+
+
+def create_community():
+    """Create the community."""
+    current_communities.service.create(
+        data=dict(
+            slug="icl",
+            metadata=dict(title="Imperial College London"),
+            access=dict(visibility="public"),
+        ),
+        identity=system_identity,
+    )
+
+
+if __name__ == "__main__":
+    app = create_app()
+    with app.app_context():
+        create_community()

--- a/app_data/create_imperial_community.py
+++ b/app_data/create_imperial_community.py
@@ -1,4 +1,4 @@
-"""Script to create_app Imperial Community."""
+"""Script to create Imperial Community."""
 
 from invenio_access.permissions import system_identity
 from invenio_app.factory import create_app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ module = [
        "invenio_app.*",
        "invenio_app_rdm.config.*",
        "invenio_assets.*",
+       "invenio_communities.*",
        "invenio_i18n.*",
        "invenio_notifications.*",
        "invenio_oauthclient.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ module = [
        "celery.*",
        "flask_login.*",
        "flask_oauthlib.*",
+       "ic_data_repo.config.*",
        "invenio_access.*",
        "invenio_app.*",
        "invenio_app_rdm.config.*",


### PR DESCRIPTION
Creates a simple script that can be called to programmatically create the icl community for deposits.

This is required as the API call to create communities is going to be blocked in deployment to prevent users from creating additional communities. Having this script is a necessary work around.