### PR TITLE
Remove path filtering from ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
       - develop
-    paths-ignore:
-      - "docs/**"
-      - "app_data/**"
-      - "docker/**"
 jobs:
   qa:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Unfortunately the path filtering applied by github actions prevents CI jobs from running entirely. This causes issues with the branch protection rules where we have jobs that are required before a PR can be merged. Backing this out for now and we might come back to it later.