### PR TITLE
Make description mandatory

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -25,6 +25,8 @@ const ContributorsField = parametrize(OptionalRoleCreatibutorsField, {
   includeRole: true,
 });
 
+const DescriptionField = parametrize(TextAreaField, { required: true });
+
 /* A simple empty element to remove non-field components via override */
 class NullElement extends Component {
   render() {
@@ -39,7 +41,7 @@ export const overriddenComponents = {
   "InvenioAppRdm.Deposit.ResourceTypeField.container": HiddenField,
   "InvenioAppRdm.Deposit.PublisherField.container": HiddenField,
   "InvenioAppRdm.Deposit.PublicationDateField.container": HiddenField,
-  "InvenioAppRdm.Deposit.DescriptionsField.container": TextAreaField,
+  "InvenioAppRdm.Deposit.DescriptionsField.container": DescriptionField,
   "InvenioAppRdm.Deposit.LicenseField.container": LimitedLicenseField,
   "InvenioAppRdm.Deposit.AccordionFieldReferences.container": HiddenField,
   "InvenioAppRdm.Deposit.CommunityHeader.container": NullElement,

--- a/site/ic_data_repo/imperial_schema.py
+++ b/site/ic_data_repo/imperial_schema.py
@@ -11,6 +11,7 @@ from invenio_rdm_records.services.schemas.metadata import CreatorSchema, Referen
 from invenio_vocabularies.services.schema import VocabularyRelationSchema
 from marshmallow import validate
 from marshmallow.fields import List, Nested, String
+from marshmallow_utils.fields import SanitizedHTML
 from werkzeug.local import LocalProxy
 
 
@@ -74,6 +75,7 @@ class ImperialMetadataSchema(MetadataSchema):
         required=True,
         validate=validate.Length(min=1, error=_("Missing data for required field.")),
     )
+    description = SanitizedHTML(required=True, validate=validate.Length(min=3))
     publisher = PublisherValue()
     publication_date = PublicationDateValue(
         load_default=lambda: current_app.config["APP_RDM_DEPOSIT_FORM_DEFAULTS"][


### PR DESCRIPTION
* Issue: https://github.com/ImperialCollegeLondon/fair-data-repository/issues/237

---

I'm able to enforce description in the backend easily. 

Whilst there is *kind of* visual indication when no description is provided (see video), I am not able to get the red 'required' arrow to appear beside he description prompt. Hence draft.

https://github.com/user-attachments/assets/4eb1df75-1618-4d78-838e-705f6af4dcc7



## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
