### PR TITLE
Metadata visibility fixed to public

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -48,4 +48,5 @@ export const overriddenComponents = {
   "InvenioAppRdm.DashboardUploads.EmptyResults.element": NullElement,
   "InvenioAppRdm.Deposit.CardDepositStatusBox.container": CardDepositStatusBox,
   "InvenioAppRdm.Deposit.FundingField.container": FundingField,
+  "ReactInvenioDeposit.MetadataAccess.layout": NullElement,
 };

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -16,7 +16,7 @@ from invenio_oauthclient.views.client import auto_redirect_login
 from invenio_rdm_records.config import RDM_PERSISTENT_IDENTIFIERS
 from marshmallow_utils.fields import NestedAttribute
 
-from ..imperial_schema import ImperialMetadataSchema
+from ..imperial_schema import ImperialAccessSchema, ImperialMetadataSchema
 from .custom_fields import *  # noqa: F401,F403
 from .utils import get_user_form_default
 
@@ -123,12 +123,13 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "creators": lambda: get_user_form_default(),
 }
 
-# This is a hacky way to overwrite the record metadata schema
-record_metadata_schema = (
-    invenio_rdm_records.services.config.RDMRecordServiceConfig.schema
-)
-record_metadata_schema._declared_fields.update(
-    {"metadata": NestedAttribute(ImperialMetadataSchema)}
+# This is a hacky way to overwrite record schemas
+record_schema = invenio_rdm_records.services.config.RDMRecordServiceConfig.schema
+record_schema._declared_fields.update(
+    {
+        "access": NestedAttribute(ImperialAccessSchema),
+        "metadata": NestedAttribute(ImperialMetadataSchema),
+    }
 )
 
 # See:

--- a/site/ic_data_repo/imperial_schema.py
+++ b/site/ic_data_repo/imperial_schema.py
@@ -7,6 +7,7 @@ This schema aligns with the record submission form customisations.
 from flask import current_app
 from invenio_i18n import lazy_gettext as _
 from invenio_rdm_records.services.schemas import MetadataSchema
+from invenio_rdm_records.services.schemas.access import AccessSchema
 from invenio_rdm_records.services.schemas.metadata import CreatorSchema, ReferenceSchema
 from invenio_vocabularies.services.schema import VocabularyRelationSchema
 from marshmallow import validate
@@ -83,3 +84,17 @@ class ImperialMetadataSchema(MetadataSchema):
         ]()
     )
     references = ReferenceValue(Nested(ReferenceSchema))
+
+
+class PublicRecordProtectionValue(String):
+    """Record protection fixed to public."""
+
+    def deserialize(self, value, attr=None, data=None, **kwargs):
+        """Return record protection fixed to public."""
+        return "public"
+
+
+class ImperialAccessSchema(AccessSchema):
+    """Imperial Access Schema."""
+
+    record = PublicRecordProtectionValue(required=True)

--- a/site/ic_data_repo/imperial_schema.py
+++ b/site/ic_data_repo/imperial_schema.py
@@ -68,7 +68,7 @@ class PublicationDateValue(String):
 
 
 class ImperialMetadataSchema(MetadataSchema):
-    """Imperial Metadata Schema that overrides five fields."""
+    """Imperial Metadata Schema."""
 
     resource_type = ResourceValue(VocabularyRelationSchema, required=True)
     creators = CreatorsValue(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,8 +58,8 @@ def get_csrf_token(client):
     raise ValueError("CSRF token not found in cookies")
 
 
-def test_metadata_schema(user_client, location, vocabularies):
-    """Test the record metadata schema."""
+def test_imperial_schema(user_client, location, vocabularies):
+    """Test the custom schemas."""
     headers = {
         "Content-Type": "application/json",
         "X-CSRFToken": get_csrf_token(user_client),
@@ -81,6 +81,10 @@ def test_metadata_schema(user_client, location, vocabularies):
             "publisher": "Fake Publisher",
             "publication_date": "1970-01-01",
         },
+        "access": {
+            "record": "restricted",
+            "files": "restricted",
+        },
     }
 
     result = user_client.post(
@@ -90,9 +94,16 @@ def test_metadata_schema(user_client, location, vocabularies):
     )
 
     assert result.status_code == 201
+
+    # Test metadata policies are enforced.
     assert result.json["metadata"]["title"] == "Test Record"
     assert result.json["metadata"]["resource_type"]["id"] == "dataset"
     assert result.json["metadata"]["creators"][0]["person_or_org"]["name"] == "Neo"
     assert "role" not in result.json["metadata"]["creators"][0]
     assert result.json["metadata"]["publisher"] == "Imperial College London"
     assert result.json["metadata"]["publication_date"] == date.today().isoformat()
+
+    # Test access policies are enforced.
+    # 'record' should be reset to public, but 'files' should remain restricted.
+    assert result.json["access"]["record"] == "public"
+    assert result.json["access"]["files"] == "restricted"


### PR DESCRIPTION
Resolves #236 

---

Prevent record metadata from being protected, only public. Files are still allowed to be either.

Backend classes `ImperialAccessSchema` and `PublicRecordProtectionValue`.

Looks like we are in luck: frontend change was indeed just replacing with a `NullElement`.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
