### PR TITLE
Limit to single or no license

### DIFF
--- a/site/ic_data_repo/imperial_schema.py
+++ b/site/ic_data_repo/imperial_schema.py
@@ -8,7 +8,11 @@ from flask import current_app
 from invenio_i18n import lazy_gettext as _
 from invenio_rdm_records.services.schemas import MetadataSchema
 from invenio_rdm_records.services.schemas.access import AccessSchema
-from invenio_rdm_records.services.schemas.metadata import CreatorSchema, ReferenceSchema
+from invenio_rdm_records.services.schemas.metadata import (
+    CreatorSchema,
+    ReferenceSchema,
+    RightsSchema,
+)
 from invenio_vocabularies.services.schema import VocabularyRelationSchema
 from marshmallow import validate
 from marshmallow.fields import List, Nested, String
@@ -84,6 +88,11 @@ class ImperialMetadataSchema(MetadataSchema):
         ]()
     )
     references = ReferenceValue(Nested(ReferenceSchema))
+    rights = List(
+        Nested(RightsSchema),
+        required=False,
+        validate=validate.Length(max=1, error=_("No more than one can be provided.")),
+    )
 
 
 class PublicRecordProtectionValue(String):

--- a/tests/data/vocabularies.yaml
+++ b/tests/data/vocabularies.yaml
@@ -1,6 +1,9 @@
 languages:
   pid-type: lng
   data-file: vocabularies/languages.yaml
+licenses:
+  pid-type: lic
+  data-file: vocabularies/licenses.csv
 resourcetypes:
   pid-type: rsrct
   data-file: vocabularies/resource_types.yaml

--- a/tests/data/vocabularies/licenses.csv
+++ b/tests/data/vocabularies/licenses.csv
@@ -1,0 +1,3 @@
+id,title__en,description__en,icon,tags,props__url,props__scheme,props__osi_approved
+cc-by-4.0,Creative Commons Attribution 4.0 International,The Creative Commons Attribution license allows re-distribution and re-use of a licensed work on the condition that the creator is appropriately credited.,cc-by-icon,"recommended,all,data",https://creativecommons.org/licenses/by/4.0/,spdx,
+cc0-1.0,Creative Commons Zero v1.0 Universal,CC0 waives copyright interest in a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach.,cc-cc0-icon,"recommended,all,data,software",https://creativecommons.org/publicdomain/zero/1.0/,spdx,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -67,47 +67,65 @@ def get_csrf_token(client):
     raise ValueError("CSRF token not found in cookies")
 
 
-def test_imperial_schema(user_client, location, vocabularies, user_depositor):
-    """Test the custom schemas."""
-    headers = {
+@pytest.fixture
+def headers(user_client):
+    """Headers for requests, including CSRF token."""
+    return {
         "Content-Type": "application/json",
         "X-CSRFToken": get_csrf_token(user_client),
     }
 
-    raw_data = {
-        "metadata": {
-            "title": "Test Record",
-            "resource_type": "fake_resource_type",
-            "creators": [
-                {
-                    "person_or_org": {
-                        "type": "personal",
-                        "name": "Neo",
-                    },
-                    "role": "the one",
+
+@pytest.fixture
+def metadata():
+    """Simple record metadata."""
+    return {
+        "title": "Test Record",
+        "description": "This is a test record.",
+        "creators": [
+            {
+                "person_or_org": {
+                    "type": "personal",
+                    "given_name": "Neo",
+                    "family_name": "Anderson",
                 },
-            ],
-            "publisher": "Fake Publisher",
-            "publication_date": "1970-01-01",
-        },
-        "access": {
-            "record": "restricted",
-            "files": "restricted",
-        },
+                "role": "the one",
+            },
+        ],
     }
 
+
+@pytest.fixture
+def access():
+    """Simple access schema."""
+    return {
+        "record": "public",
+        "files": "public",
+    }
+
+
+def test_metadata_schema(
+    user_client, location, vocabularies, user_depositor, headers, metadata, access
+):
+    """Test that the metadata schema is enforced."""
+    metadata["resource_type"] = "fake_resource_type"
+    metadata["publisher"] = "Fake Publisher"
+    metadata["publication_date"] = "1970-01-01"
+    access["record"] = "restricted"
+    access["files"] = "restricted"
     result = user_client.post(
         "/api/records",
-        json=raw_data,
+        json={"metadata": metadata, "access": access},
         headers=headers,
     )
-
     assert result.status_code == 201
 
     # Test metadata policies are enforced.
     assert result.json["metadata"]["title"] == "Test Record"
     assert result.json["metadata"]["resource_type"]["id"] == "dataset"
-    assert result.json["metadata"]["creators"][0]["person_or_org"]["name"] == "Neo"
+    assert (
+        result.json["metadata"]["creators"][0]["person_or_org"]["given_name"] == "Neo"
+    )
     assert "role" not in result.json["metadata"]["creators"][0]
     assert result.json["metadata"]["publisher"] == "Imperial College London"
     assert result.json["metadata"]["publication_date"] == date.today().isoformat()
@@ -116,6 +134,41 @@ def test_imperial_schema(user_client, location, vocabularies, user_depositor):
     # 'record' should be reset to public, but 'files' should remain restricted.
     assert result.json["access"]["record"] == "public"
     assert result.json["access"]["files"] == "restricted"
+
+
+def test_metadata_schema_rights(
+    user_client, location, vocabularies, user_depositor, headers, metadata
+):
+    """Test that the rights schema is enforced."""
+    # Test that no license is accepted.
+    metadata["rights"] = []
+    result = user_client.post(
+        "/api/records",
+        json={"metadata": metadata},
+        headers=headers,
+    )
+    assert result.status_code == 201
+    assert "rights" not in result.json["metadata"]
+
+    # Test that a single license is accepted.
+    metadata["rights"] = [{"id": "cc0-1.0"}]
+    result = user_client.post(
+        "/api/records",
+        json={"metadata": metadata},
+        headers=headers,
+    )
+    assert result.status_code == 201
+    assert result.json["metadata"]["rights"][0]["id"] == "cc0-1.0"
+
+    # Test that multiple rights entries are not accepted.
+    metadata["rights"] = [{"id": "cc0-1.0"}, {"id": "cc-by-4.0"}]
+    result = user_client.post(
+        "/api/records",
+        json={"metadata": metadata},
+        headers=headers,
+    )
+    assert result.status_code == 201
+    assert result.json["errors"][0]["messages"][0].startswith("No more than")
 
 
 def test_deposit_view_permissions(user, user_client, db, vocabularies, app):


### PR DESCRIPTION
Resolves https://github.com/ImperialCollegeLondon/fair-data-repository/issues/248

---

Limit to one or no licenses. 

Requires a vocabulary update in the testsuite (NB: THIS IS NOT THE SAME AS THE VOCABULARY IN `app_data`)

Added tests, and started refactoring api requests into fixtures.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
