### PR TITLE
Affiliation Vocabulary Task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,6 @@ RUN cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
     invenio collect --verbose  && \
     invenio webpack buildall
 
-# get full set of affiliations data
-RUN mv ${INVENIO_INSTANCE_PATH}/app_data/vocabularies/affiliations_ror_full.yaml ${INVENIO_INSTANCE_PATH}/app_data/vocabularies/affiliations_ror.yaml
-
 # Make directory owned by Invenio user
 RUN chown -R invenio test_data/ ${INVENIO_INSTANCE_PATH}/app_data/
 

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -10,15 +10,15 @@ import os
 from datetime import datetime, timedelta
 
 import invenio_rdm_records
-from invenio_app_rdm.config import CELERY_BEAT_SCHEDULE
+from invenio_app_rdm.config import (
+    CELERY_BEAT_SCHEDULE,
+    VOCABULARIES_DATASTREAM_READERS,
+    VOCABULARIES_DATASTREAM_WRITERS,
+)
 from invenio_notifications.backends.email import EmailNotificationBackend
 from invenio_oauthclient.views.client import auto_redirect_login
 from invenio_rdm_records.config import RDM_PERSISTENT_IDENTIFIERS
 from invenio_rdm_records.services.components import DefaultRecordsComponents
-from invenio_vocabularies.config import (
-    VOCABULARIES_DATASTREAM_READERS,
-    VOCABULARIES_DATASTREAM_WRITERS,
-)
 from marshmallow_utils.fields import NestedAttribute
 
 from ..datastreams import AffiliationsWriter, StreamingYamlSequenceReader

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -15,8 +15,13 @@ from invenio_notifications.backends.email import EmailNotificationBackend
 from invenio_oauthclient.views.client import auto_redirect_login
 from invenio_rdm_records.config import RDM_PERSISTENT_IDENTIFIERS
 from invenio_rdm_records.services.components import DefaultRecordsComponents
+from invenio_vocabularies.config import (
+    VOCABULARIES_DATASTREAM_READERS,
+    VOCABULARIES_DATASTREAM_WRITERS,
+)
 from marshmallow_utils.fields import NestedAttribute
 
+from ..datastreams import AffiliationsWriter, StreamingYamlSequenceReader
 from ..imperial_schema import ImperialAccessSchema, ImperialMetadataSchema
 from ..permissions import ImperialRecordPermissionPolicy
 from ..service_components import SymplecticComponent
@@ -256,3 +261,6 @@ SYMPLECTIC_ENABLED = bool(SYMPLECTIC_API_URL and SYMPLECTIC_API_SUBSCRIPTION_KEY
 RDM_PERMISSION_POLICY = ImperialRecordPermissionPolicy
 
 RDM_RECORDS_SERVICE_COMPONENTS = DefaultRecordsComponents + [SymplecticComponent]
+
+VOCABULARIES_DATASTREAM_WRITERS["affiliations-service"] = AffiliationsWriter
+VOCABULARIES_DATASTREAM_READERS["stream-yaml"] = StreamingYamlSequenceReader

--- a/site/ic_data_repo/datastreams.py
+++ b/site/ic_data_repo/datastreams.py
@@ -1,0 +1,37 @@
+"""Datastreams for vocabulary entries."""
+
+import yaml
+from invenio_vocabularies.datastreams.readers import BaseReader
+from invenio_vocabularies.datastreams.writers import ServiceWriter
+
+
+class AffiliationsWriter(ServiceWriter):
+    """A writer for vocabulary entries to the affiliations service."""
+
+    def __init__(self, *args, **kwargs):
+        """Constructor."""
+        service_or_name = kwargs.pop("service_or_name", "affiliations")
+        super().__init__(service_or_name=service_or_name, *args, **kwargs)
+
+    def _entry_id(self, entry):
+        """Get the id from an entry."""
+        return entry["id"]
+
+
+class StreamingYamlSequenceReader(BaseReader):
+    """A reader for YAML sequences that streams the data as it is read.
+
+    Streams the first sequence found in the first document only of a YAML file.
+    """
+
+    def _iter(self, fp, *args, **kwargs):
+        loader = yaml.SafeLoader(fp)
+
+        # consume file until we hit the first sequence
+        while not isinstance(loader.get_event(), yaml.events.SequenceStartEvent):
+            pass
+
+        # recursively load individual items until we get to the end of the sequenc
+        while not isinstance(loader.peek_event(), yaml.events.SequenceEndEvent):
+            loader.constructed_objects = {}  # stop memory accumulation in loader cache
+            yield loader.construct_object(loader.compose_node(None, None), deep=True)

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -4,6 +4,7 @@ In particular, this includes tasks to be run periodically in the background.
 """
 
 from io import BytesIO
+from pathlib import Path
 
 import requests
 from celery import shared_task
@@ -69,3 +70,29 @@ def export_record_to_symplectic(record) -> None:
         current_app.config["SYMPLECTIC_API_SUBSCRIPTION_KEY"],
     )
     client.create_record(record)
+
+
+@shared_task
+def import_full_affilations_vocab():
+    """Import the full affiliations vocabulary from YAML file in app_data."""
+    datastream_config = {
+        "readers": [
+            {
+                "type": "stream-yaml",
+                "args": {
+                    "origin": Path(current_app.instance_path)
+                    / "app_data"
+                    / "vocabularies"
+                    / "affiliations_ror_full.yaml",
+                },
+            },
+        ],
+        "transformers": [],
+        "writers": [
+            {
+                "type": "affiliations-service",
+                "args": {"identity": system_identity, "update": True},
+            }
+        ],
+    }
+    import_to_vocabulary(datastream_config, allow_errors=False)

--- a/site/ic_data_repo/tasks.py
+++ b/site/ic_data_repo/tasks.py
@@ -46,7 +46,9 @@ def update_funders_vocabulary(archive_download_url: str) -> None:
                     "regex": r"-ror-data\.json",
                 },
             },
-            {"type": "json"},
+            # exploiting that yaml is a json superset use our streaming reader
+            # helps avoid memory issues in deployment
+            {"type": "stream-yaml"},
         ],
         "transformers": [{"type": "ror-funder"}],
         "writers": [


### PR DESCRIPTION
This pull request allows populating the `affiliations` vocabulary with the full set of (~100,000) organisations via background task. Previously we were using a overwrite in the `Dockerfile` to use the full affilations set in the docker image. That was a bit hacky however and besides being slightly obscure because it was loaded along with the rest of fixture data was extending the deployment time.

These changes allow `affiliations` loading to take place after deployment via a background task. This will be triggered by an init job during deployment. Now that the worker pods have to handle the full affiliation dataset it's also been necessary to provide a streaming capability to avoid memory issues with the workers.
