### PR TITLE
Add dnf upgrade to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # bootstrap script located in ./scripts/bootstrap.
 
 FROM registry.cern.ch/inveniosoftware/almalinux:1
+RUN dnf upgrade -y && dnf clean all
 
 COPY site ./site
 COPY Pipfile Pipfile.lock ./


### PR DESCRIPTION
Add a dnf upgrade to the docker build process. This means we get the latest version of OS packages and helps cover potential security issues.