### PR TITLE
Add trivy github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,18 @@ jobs:
         id: export-data
         run: |
           echo "image_tag_with_sha=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+      - name: Scan backend Docker image with Trivy
+        uses: aquasecurity/trivy-action@v0.31
+        with:
+          image-ref: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: "table"
+          exit-code: 0 # Do not fail the build on vulnerabilities
+          output: trivy-backend.txt
+      - name: Upload Trivy backend scan report
+        uses: actions/upload-artifact@v3
+        with:
+          name: trivy-backend-report
+          path: trivy-backend.txt
   deploy:
     needs: build-and-publish
     uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
To give better visibility of our security posture this PR adds a step using [trivy](https://github.com/aquasecurity/trivy-action). This produces a report on security issues within the image and uploads the report as a artifact. The scan is fairly permissive in that it will never fail the workflow. As we require manual confirmation before a deployment this provides an opportunity for the deployer to review the report and decide on any required actions.