### PR TITLE
adding the function to link records in symplectic

### DIFF
--- a/site/ic_data_repo/symplectic_interface.py
+++ b/site/ic_data_repo/symplectic_interface.py
@@ -243,3 +243,62 @@ class SymplecticClient:
             headers=self.headers,
         )
         response.raise_for_status()
+
+        root = etree.fromstring(response.content)
+        ns = {"api": "http://www.symplectic.co.uk/publications/api"}
+
+        # Extract <api:object> id
+        object_elem = root.find(".//api:object", namespaces=ns)
+        object_id = object_elem.get("id") if object_elem is not None else None
+
+        # Extract all <api:text> for fields named c-related-doi
+        related_doi_text = []
+        for field in root.findall(".//api:field[@name='c-related-doi']", namespaces=ns):
+            text_elem = field.find("api:text", namespaces=ns)
+            if text_elem is not None and text_elem.text:
+                related_doi_text.append(text_elem.text)
+
+        # Fetch related object IDs
+        related_object_id = self.fetch_related_objects(related_doi_text)
+        if related_object_id:
+            self.link_related_records(object_id, related_object_id)
+
+        return object_id, related_doi_text, related_object_id
+
+    def fetch_related_objects(self, related_doi_texts):
+        """Search for object_ids to link to based on related DOIs."""
+        results = []
+        for doi in related_doi_texts:
+            url = f'{self.api_url}/publications?detail=single-record&query=doi="{doi}"'
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+            results.append(response.text)
+
+        root = etree.fromstring(response.content)
+        ns = {"api": "http://www.symplectic.co.uk/publications/api"}
+
+        object_elem = root.find(".//api:object", namespaces=ns)
+        related_object_id = object_elem.get("id") if object_elem is not None else None
+
+        if related_object_id:
+            return related_object_id
+        return None
+
+    def link_related_records(self, from_object_id, to_object_id):
+        """Link related records using the object IDs from the responses from the API."""
+        ns = "http://www.symplectic.co.uk/publications/api"
+        root = etree.Element("import-relationship", xmlns=ns)
+        etree.SubElement(root, "from-object").text = f"publication({from_object_id})"
+        etree.SubElement(root, "to-object").text = f"publication({to_object_id})"
+        etree.SubElement(root, "type-id").text = "1"
+
+        xml_data = etree.tostring(root, encoding="unicode", pretty_print=True)
+
+        url = f"{self.api_url}/relationships"
+        response = requests.post(
+            url,
+            data=xml_data,
+            headers=self.headers,
+        )
+        response.raise_for_status()
+        return response


### PR DESCRIPTION
* Issue: https://github.com/ImperialCollegeLondon/fair-data-repository/issues/226

---
There is a new variable that gets the object_id of the created record from the response and is used later. 
I have added 2 new functions, `fetch_related_objects` this gets the DOI mentioned in related works uses a GET request to find any related DOI's in Simplistic and gets their object ID and the returns it in the create_records function. 
The function `link related records` will get the 2 object_id's mentioned above and makes another API call to Symplectic to create the relationship between the 2 records if related works exist. 

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
