### PR TITLE
Check user permissions when rendering upload button in dashboard

### DIFF
--- a/templates/semantic-ui/invenio_app_rdm/users/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/users/header.html
@@ -21,9 +21,11 @@ License; see LICENSE file for more details. #}
             </div>
         </div>
         {% if active_dashboard_menu_item == "uploads" %}
-        <a class="ui tiny button positive left labeled icon m-0" href="/uploads/new?community=icl">
-            <i class="upload icon" aria-hidden="true"></i>
-            {{ _('New upload') }}
+            {% if_user_can "create" %}
+            <a class="ui tiny button positive left labeled icon m-0" href="/uploads/new?community=icl">
+                <i class="upload icon" aria-hidden="true"></i>
+                {{ _('New upload') }}
+            {% end_if_user_can %}
         </a>
         {% endif %} {% if active_dashboard_menu_item == "communities" %}
         <a class="ui tiny button positive left labeled icon m-0" href="/communities/new">


### PR DESCRIPTION
Fixes #305. Uses the same mechanism used to conceal the plus menu in the navbar.