### PR TITLE
Remove copyright metadata field

### DIFF
--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -63,4 +63,5 @@ export const overriddenComponents = {
   "InvenioAppRdm.Deposit.FundingField.container": FundingField,
   "ReactInvenioDeposit.MetadataAccess.layout": NullElement,
   "InvenioRdmRecords.SubmitReviewModal.container": SubmitReviewModalComponent,
+  "InvenioAppRdm.Deposit.CopyrightsField.container": HiddenField,
 };

--- a/site/ic_data_repo/imperial_schema.py
+++ b/site/ic_data_repo/imperial_schema.py
@@ -93,6 +93,7 @@ class ImperialMetadataSchema(MetadataSchema):
         required=False,
         validate=validate.Length(max=1, error=_("No more than one can be provided.")),
     )
+    copyright = SanitizedHTML(dump_only=True)
 
 
 class PublicRecordProtectionValue(String):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -98,3 +98,20 @@ def test_metadata_schema_rights(
     )
     assert result.status_code == 201
     assert result.json["errors"][0]["messages"][0].startswith("No more than")
+
+
+def test_metadata_schema_copyright(
+    client, location, vocabularies, user_depositor, api_headers, metadata
+):
+    """Test that the copyright metadata field is blocked."""
+    metadata["copyright"] = "some data"
+    result = client.post(
+        "/records",
+        json={"metadata": metadata},
+        headers=api_headers,
+    )
+    assert result.status_code == 201
+    error = result.json["errors"][0]
+    assert error["field"] == "metadata.copyright"
+    assert error["messages"] == ["Unknown field."]
+    assert "copyright" not in result.json["metadata"]


### PR DESCRIPTION
Invenio v13 added a new copyright field to the metadata. It's not currently clear if this is something we would want to adopt in our deployment but I don't want to block adopting v13 until we have a clear answer. As it's pretty simple to remove the field and it can be restored later this PR removes it for the time being.