### PR TITLE
Fix award vocabulary entries for industry funders

### DIFF
--- a/app_data/vocabularies/funders.yaml
+++ b/app_data/vocabularies/funders.yaml
@@ -182,3 +182,8 @@
   name: The Faraday Institution
   title:
     en: The Faraday Institution
+- country: GB
+  id: industry
+  name: Industry
+  title:
+    en: Industry

--- a/site/ic_data_repo/vocabs.py
+++ b/site/ic_data_repo/vocabs.py
@@ -322,7 +322,7 @@ def _get_funder_org_id(row: dict[str, str]) -> dict[str, str] | None:
     funder = row["Funder"]
     sponsor = row["SPONSOR"]
     if funder == "Industry":
-        return dict(name=funder)
+        return dict(id=funder.lower())
     if funder != sponsor:
         return None
     try:


### PR DESCRIPTION
When populating the award vocabulary data because of the wide variety of organisations we are unable to map these entries to specific funder bodies. Instead in the award data schema we've been providing `{"name": "Industry"}` as the funding information. Whilst this is technically supported by the schema, it turns out that the web UI will not allow adding an award entry unless it provides the funder information in the form `{"id": FUNDER_ID}` where `FUNDER_ID` is a key to an entry in the funders vocabulary. To support the industrial funder case therefore this PR:
- adds a generic `Industry` entry in the funder vocabulary.
- uses the form `{"id": "industry"}` for award metadata.