### PR TITLE
Permanently activate venv in Docker image environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,4 +12,3 @@
 !assets
 !test_data
 test_data/10.14469_hpc_*
-!docker/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,11 @@ RUN chgrp -R 0 ${WORKING_DIR} && \
 COPY site ./site
 COPY Pipfile Pipfile.lock ./
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy --extra-pip-args="--no-cache-dir"
+ENV VIRTUAL_ENV_PATH=${WORKING_DIR}/src/.venv
+ENV PATH="$VIRTUAL_ENV_PATH/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONNOUSERSITE=1
 
 COPY ./docker/uwsgi/ ${INVENIO_INSTANCE_PATH}
 COPY ./invenio.cfg ${INVENIO_INSTANCE_PATH}
@@ -98,12 +103,8 @@ COPY ./ .
 
 RUN cp -r ./static/. ${INVENIO_INSTANCE_PATH}/static/ && \
     cp -r ./assets/. ${INVENIO_INSTANCE_PATH}/assets/ && \
-    /opt/invenio/src/.venv/bin/invenio collect --verbose  && \
-    /opt/invenio/src/.venv/bin/invenio webpack buildall && \
+    invenio collect --verbose  && \
+    invenio webpack buildall && \
     npm cache clean --force
 
 RUN chown -R invenio test_data/ ${INVENIO_INSTANCE_PATH}/app_data/
-COPY ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Activate the virtual environment
-source /opt/invenio/src/.venv/bin/activate
-
-# Start the application
-exec "$@"


### PR DESCRIPTION
As part of the python 3.11 upgrade we moved to having python dependencies for Invenio in a dedicated virtual environment. This caused some problems with some of the development infrastructure and deployment with the Helm charts that expected executable in the virtual environment to be discoverable. We tried to work around this by adding an entrypoint to take care of the virtual environment activation however this has not proven that robust, particularly as Kubernetes ignores most entrypoints. This PR uses a more robust strategy to permanently activate the virtual environment for any processes run inside the container.