### PR TITLE
E2E: add decline submission review test and stabilise submission review test flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: flake8
         additional_dependencies: ["flake8-docstrings", "flake8-pyproject"]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 1.0.0
     hooks:
       - id: mdformat
         additional_dependencies:

--- a/docs/index.md
+++ b/docs/index.md
@@ -322,6 +322,7 @@ file is also provided in `ic_data_repo.config.production`.
 ## Test Data
 
 !!! note
+
     This functionality is not currently working.
 
 Instructions for accessing and working with realistic test data records are provided in

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -104,9 +104,9 @@ INSTANCE_THEME_FILE = "./less/theme.less"
 # See:
 # https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/config.py
 
-SITE_UI_URL = "https://127.0.0.1"
+SITE_UI_URL = "https://127.0.0.1:5000"
 
-SITE_API_URL = "https://127.0.0.1/api"
+SITE_API_URL = "https://127.0.0.1:5000/api"
 
 APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "resource_type": "dataset",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,6 +24,8 @@ def logout(driver):
     driver.get(f"{pytest.base_url}/logout")
     WebDriverWait(driver, timeout=10).until(
         lambda d: d.current_url == f"{pytest.base_url}/"
+        and "user-profile-dropdown-btn" not in d.page_source
+        and "Log in" in d.page_source
     )
 
 

--- a/tests/e2e/test_submission_review.py
+++ b/tests/e2e/test_submission_review.py
@@ -43,13 +43,60 @@ def test_submission_review_accept(driver, submission_request_url):
     )
 
     # Check for accepted status
-    status_container = WebDriverWait(driver, timeout=10).until(
+    accepted_status = WebDriverWait(driver, timeout=10).until(
         EC.visibility_of_element_located(
-            (By.XPATH, "//h3[normalize-space()='Status']/following-sibling::div[1]")
+            (
+                By.XPATH,
+                "//h3[normalize-space()='Status']/following-sibling::div[1]"
+                "//span[normalize-space()='Accepted']",
+            )
         )
     )
-    accepted_status = status_container.find_element(
-        By.XPATH, ".//span[normalize-space()='Accepted']"
-    )
     driver.get_full_page_screenshot_as_file(str(ARTIFACTS_DIR / "accepted_status.png"))
-    assert accepted_status.is_displayed()
+    assert accepted_status is not None
+
+
+def test_submission_review_decline(driver, submission_request_url):
+    """Superuser can open and decline a submission request."""
+    login(driver, REVIEWER_EMAIL, TEST_PASSWORD, "/communities/icl/requests/")
+    WebDriverWait(driver, timeout=10).until(
+        lambda d: d.current_url.endswith("/communities/icl/requests/")
+    )
+
+    driver.get(submission_request_url)
+    WebDriverWait(driver, timeout=10).until(
+        lambda d: d.current_url == submission_request_url
+    )
+
+    decline_locator = (By.XPATH, "//button[normalize-space()='Decline']")
+    decline_btn = WebDriverWait(driver, timeout=10).until(
+        EC.element_to_be_clickable(decline_locator)
+    )
+    decline_btn.click()
+
+    decline_modal = WebDriverWait(driver, timeout=10).until(
+        EC.visibility_of_element_located((By.ID, "decline"))
+    )
+    confirm_decline_btn = WebDriverWait(driver, timeout=10).until(
+        lambda d: decline_modal.find_element(
+            By.XPATH, ".//button[normalize-space()='Decline']"
+        )
+    )
+    confirm_decline_btn.click()
+
+    WebDriverWait(driver, timeout=10).until(
+        lambda d: d.current_url == submission_request_url
+    )
+
+    # Check for declined status
+    declined_status = WebDriverWait(driver, timeout=10).until(
+        EC.visibility_of_element_located(
+            (
+                By.XPATH,
+                "//h3[normalize-space()='Status']/following-sibling::div[1]"
+                "//span[normalize-space()='Declined']",
+            )
+        )
+    )
+    driver.get_full_page_screenshot_as_file(str(ARTIFACTS_DIR / "declined_status.png"))
+    assert declined_status is not None


### PR DESCRIPTION
* Issue: #377 

---

- Adds end-to-end coverage for declining a submission request.
- Includes small test reliability fixes discovered while validating the new test, so the tests pass consistently.

---

A new test was added to test the decline review workflow. This should be fairly straightforward to review.

In doing this, however, my tests had started failing. So I have had to make some small changes to stabilise things there also:
- More robust wait criteria for `logout`, which addresses intermittent `TimeoutException`
- I started seeing a `StaleElementReferenceException` at the final step in `test_submission_review_accept/decline`. It seems that although it was finding the status container, it wasn't finding the `Accepted` or `Declined` spans. Likely the UI (and therefore the DOM) was updating in between these two steps and causing the error. So I combined the `accepted_status` and `visibility_of_element_located` into `WebDriverWait`. This has a side benefit of being a bit cleaner.
- The final `assert` in the two tests were returning an unexpected falsely result, even though the visibility wait had already succeeded (`is_displayed` seems brittle, idk 🤷 ). Since Selenium already guarantees the found element is visible before returning it, calling `is_displayed` again is redundant. I kept the `is not None` assert for clarity.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
