### PR TITLE
update mdformat to resolve more_itertools compatibility issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: flake8
         additional_dependencies: ["flake8-docstrings", "flake8-pyproject"]
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 1.0.0
     hooks:
       - id: mdformat
         additional_dependencies:

--- a/docs/index.md
+++ b/docs/index.md
@@ -322,6 +322,7 @@ file is also provided in `ic_data_repo.config.production`.
 ## Test Data
 
 !!! note
+
     This functionality is not currently working.
 
 Instructions for accessing and working with realistic test data records are provided in


### PR DESCRIPTION
Change the mdformat version from `0.7.17` to `1.0.0`. The issue is that mdformat-mkdocs in v0.7.17 has an incompatible dependency on `more_itertools`. This was causing mdformat failure in pre-commit.ci. Let's hope newer versions of mdformat have this fixed.

## Developer Checklist

*Developers should review and confirm each of these items before requesting review*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated

## Reviewer Checklist

*Reviewers should review and confirm each of these items before approval*
*If there are multiple reviewers, this section can be duplicated for each reviewer*

* [ ] Code meets acceptance criteria from issue
* [ ] Unit tests are written and all pass
* [ ] User Test Scripts (if required) are written and have been run through
* [ ] Code documentation and related non-code documentation has all been updated
* [ ] Migation has been created and tested

## Testing

*List user test scripts that need to be run*

*List any non-unit test scripts that need to be run*
