### PR TITLE
Configure npm as default javascript_package_manager

### DIFF
--- a/.invenio
+++ b/.invenio
@@ -1,6 +1,7 @@
 [cli]
 flavour = RDM
 logfile = /logs/invenio-cli.log
+javascript_package_manager = npm
 
 [cookiecutter]
 project_name = Helix


### PR DESCRIPTION
invenio-cli v1.12.0 makes the interesting choice of making [pnpm](https://pnpm.io/) the default javascript package manager. We may want to adopt this but initially we'll pin to what we know works.