### PR TITLE
Fix file upload issue in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,4 +72,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: invenio-cli-app-log
-          path: app.log
+          path: |
+            app.log
+            artifacts/**/*.png
+            artifacts/**/*.html
+            artifacts/**/*.txt
+            artifacts/**/*.log

--- a/site/ic_data_repo/config/settings.py
+++ b/site/ic_data_repo/config/settings.py
@@ -104,9 +104,9 @@ INSTANCE_THEME_FILE = "./less/theme.less"
 # See:
 # https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/config.py
 
-SITE_UI_URL = "https://127.0.0.1"
+SITE_UI_URL = "https://127.0.0.1:5000"
 
-SITE_API_URL = "https://127.0.0.1/api"
+SITE_API_URL = "https://127.0.0.1:5000/api"
 
 APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "resource_type": "dataset",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -12,6 +12,7 @@ pytest.base_url = "https://127.0.0.1:5000"
 ARTIFACTS_DIR = Path("artifacts")
 ARTIFACTS_DIR.mkdir(exist_ok=True)
 
+
 @pytest.fixture
 def driver(request):
     """Selenium WebDriver fixture."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,7 @@
 """Global test fixtures for end-to-end tests."""
 
+from pathlib import Path
+
 import pytest
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -7,13 +9,17 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 pytest.base_url = "https://127.0.0.1:5000"
 
+ARTIFACTS_DIR = Path("artifacts")
+ARTIFACTS_DIR.mkdir(exist_ok=True)
 
 @pytest.fixture
-def driver():
+def driver(request):
     """Selenium WebDriver fixture."""
     options = webdriver.FirefoxOptions()
     options.add_argument("--headless")
+    options.set_capability("acceptInsecureCerts", True)
     _driver = webdriver.Firefox(options=options)
+    _driver.set_window_size(1920, 1080)
     _driver.get(pytest.base_url)
 
     body = _driver.find_element(By.TAG_NAME, "body")
@@ -21,4 +27,9 @@ def driver():
     wait.until(lambda _: body.is_displayed())
 
     yield _driver
+
+    test_name = request.node.originalname
+    screenshot_path = ARTIFACTS_DIR / f"{test_name}.png"
+    _driver.get_full_page_screenshot_as_file(str(screenshot_path))
+
     _driver.quit()


### PR DESCRIPTION
We've been having consistent failures with tests that involve file uploads. Eventually tracked this down to a [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) issue. Oddly I found I was able to reproduce even outside of the test suite but I've no idea why this issue has arisen recently because these settings haven't been changed over the course of the whole project. Anyway this fix appears to work.

@TinyMarsh I pinched some components from your branches to put into this ones which may cause trouble later.